### PR TITLE
fix: relative pathing & incorrect instanceID access

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,6 +13,8 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.8" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="MinVer" Version="7.0.0" />

--- a/src/KAST.Infrastructure/KAST.Infrastructure.csproj
+++ b/src/KAST.Infrastructure/KAST.Infrastructure.csproj
@@ -9,6 +9,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="SteamKit2" />
   </ItemGroup>

--- a/src/KAST.Infrastructure/Services/ServerInstanceService.cs
+++ b/src/KAST.Infrastructure/Services/ServerInstanceService.cs
@@ -155,7 +155,7 @@ public class ServerInstanceService(
             return;
 
         // 1) Per-instance config/profile directory: {InstallPath}/KAST/{id}
-        var configDir = Path.Combine(instance.InstallPath, "KAST", instance.Id.ToString());
+        var configDir = GetInstanceConfigDirectory(instance);
         TryDeleteDirectory(configDir, recursive: true);
 
         // 1b) On Linux, clean up the profile symlink we created in the system profiles dir.
@@ -164,7 +164,7 @@ public class ServerInstanceService(
 
         // 2) Mod symlinks created for this instance's mods (don't touch the mod
         //    source itself — that's shared and owned by ModService).
-        var modsDir = Path.Combine(instance.InstallPath, "mods");
+        var modsDir = GetInstanceModsDirectory(instance);
         if (Directory.Exists(modsDir))
         {
             foreach (var modLink in instance.Mods)
@@ -476,7 +476,7 @@ public class ServerInstanceService(
         activity?.SetTag("instance.name",        instance.Name);
         activity?.SetTag("instance.mods_total",  instance.Mods.Count);
 
-        var modsDir = Path.Combine(instance.InstallPath, "mods");
+        var modsDir = GetInstanceModsDirectory(instance);
         Directory.CreateDirectory(modsDir);
 
         int linkedCount = 0;
@@ -505,11 +505,19 @@ public class ServerInstanceService(
 
     private static string GetServerExecutable(ServerInstance instance)
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            return Path.Combine(instance.InstallPath, "arma3server_x64.exe");
+        var installPath = Path.GetFullPath(instance.InstallPath);
 
-        return Path.Combine(instance.InstallPath, "arma3server_x64");
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return Path.Combine(installPath, "arma3server_x64.exe");
+
+        return Path.Combine(installPath, "arma3server_x64");
     }
+
+    private static string GetInstanceConfigDirectory(ServerInstance instance)
+        => Path.GetFullPath(Path.Combine(instance.InstallPath, "KAST", instance.Id.ToString()));
+
+    private static string GetInstanceModsDirectory(ServerInstance instance)
+        => Path.GetFullPath(Path.Combine(instance.InstallPath, "mods"));
 
     public void WriteConfigFiles(ServerInstance instance)
     {
@@ -517,7 +525,7 @@ public class ServerInstanceService(
             Directory.CreateDirectory(instance.InstallPath);
 
         // Per-instance config directory
-        var configDir = Path.Combine(instance.InstallPath, "KAST", instance.Id.ToString());
+        var configDir = GetInstanceConfigDirectory(instance);
         Directory.CreateDirectory(configDir);
 
         if (instance.ServerCfgContent != null)
@@ -554,7 +562,7 @@ public class ServerInstanceService(
 
     private static string BuildLaunchArguments(ServerInstance instance)
     {
-        var configDir = Path.Combine(instance.InstallPath, "KAST");
+        var configDir = GetInstanceConfigDirectory(instance);
         var profileName = $"server_{instance.Id}";
 
         var args = new List<string>
@@ -638,7 +646,7 @@ public class ServerInstanceService(
         return instance.Mods
             .Where(m => m.IsClientSide)
             .OrderBy(m => m.LoadOrder)
-            .Select(m => Path.Combine(instance.InstallPath, "mods", $"@{SanitizeModName(m.SteamMod.Name)}"))
+            .Select(m => Path.Combine(GetInstanceModsDirectory(instance), $"@{SanitizeModName(m.SteamMod.Name)}"))
             .ToList();
     }
 
@@ -647,7 +655,7 @@ public class ServerInstanceService(
         var serverMods = instance.Mods
             .Where(m => m.IsServerSide)
             .OrderBy(m => m.LoadOrder)
-            .Select(m => Path.Combine(instance.InstallPath, "mods", $"@{SanitizeModName(m.SteamMod.Name)}"));
+            .Select(m => Path.Combine(GetInstanceModsDirectory(instance), $"@{SanitizeModName(m.SteamMod.Name)}"));
 
         return string.Join(";", serverMods);
     }

--- a/src/KAST.Infrastructure/Services/ServerInstanceService.cs
+++ b/src/KAST.Infrastructure/Services/ServerInstanceService.cs
@@ -7,6 +7,7 @@ using KAST.Core.Models;
 using KAST.Infrastructure.Data;
 using KAST.Infrastructure.Telemetry;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 namespace KAST.Infrastructure.Services;
@@ -15,7 +16,8 @@ public class ServerInstanceService(
     KastDbContext db,
     IProcessManagerService processManager,
     IAppEventBroadcaster broadcaster,
-    ILogger<ServerInstanceService> logger) : IServerInstanceService
+    ILogger<ServerInstanceService> logger,
+    IHostEnvironment? hostEnvironment = null) : IServerInstanceService
 {
     public async Task<IReadOnlyList<ServerInstance>> GetAllInstancesAsync(CancellationToken ct = default)
         => await db.ServerInstances
@@ -193,7 +195,7 @@ public class ServerInstanceService(
         // 3) Full install path — only when no other instance is using it.
         if (wipeInstallPath)
         {
-            TryDeleteDirectory(instance.InstallPath, recursive: true);
+            TryDeleteDirectory(GetInstanceInstallDirectory(instance), recursive: true);
             logger.LogInformation(
                 "Wiped install directory {Path} for instance {Id}",
                 instance.InstallPath, instance.Id);
@@ -503,9 +505,9 @@ public class ServerInstanceService(
         activity?.SetTag("instance.mods_linked", linkedCount);
     }
 
-    private static string GetServerExecutable(ServerInstance instance)
+    private string GetServerExecutable(ServerInstance instance)
     {
-        var installPath = Path.GetFullPath(instance.InstallPath);
+        var installPath = GetInstanceInstallDirectory(instance);
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             return Path.Combine(installPath, "arma3server_x64.exe");
@@ -513,16 +515,24 @@ public class ServerInstanceService(
         return Path.Combine(installPath, "arma3server_x64");
     }
 
-    private static string GetInstanceConfigDirectory(ServerInstance instance)
-        => Path.GetFullPath(Path.Combine(instance.InstallPath, "KAST", instance.Id.ToString()));
+    private string GetInstanceInstallDirectory(ServerInstance instance)
+    {
+        var installPath = Environment.ExpandEnvironmentVariables(instance.InstallPath);
+        return Path.IsPathFullyQualified(installPath)
+            ? Path.GetFullPath(installPath)
+            : Path.GetFullPath(installPath, hostEnvironment?.ContentRootPath ?? AppContext.BaseDirectory);
+    }
 
-    private static string GetInstanceModsDirectory(ServerInstance instance)
-        => Path.GetFullPath(Path.Combine(instance.InstallPath, "mods"));
+    private string GetInstanceConfigDirectory(ServerInstance instance)
+        => Path.Combine(GetInstanceInstallDirectory(instance), "KAST", instance.Id.ToString());
+
+    private string GetInstanceModsDirectory(ServerInstance instance)
+        => Path.Combine(GetInstanceInstallDirectory(instance), "mods");
 
     public void WriteConfigFiles(ServerInstance instance)
     {
         if (!string.IsNullOrEmpty(instance.InstallPath))
-            Directory.CreateDirectory(instance.InstallPath);
+            Directory.CreateDirectory(GetInstanceInstallDirectory(instance));
 
         // Per-instance config directory
         var configDir = GetInstanceConfigDirectory(instance);
@@ -560,7 +570,7 @@ public class ServerInstanceService(
         return $"{executable} {args}";
     }
 
-    private static string BuildLaunchArguments(ServerInstance instance)
+    private string BuildLaunchArguments(ServerInstance instance)
     {
         var configDir = GetInstanceConfigDirectory(instance);
         var profileName = $"server_{instance.Id}";
@@ -613,7 +623,7 @@ public class ServerInstanceService(
             args.Add($"-cpuCount={cfg.CpuCount}");
     }
 
-    private static void AddModArgs(ServerInstance instance, List<string> args)
+    private void AddModArgs(ServerInstance instance, List<string> args)
     {
         var dlcMods = GetDlcModsList(instance);
         var clientMods = GetClientModsList(instance);
@@ -641,7 +651,7 @@ public class ServerInstanceService(
         return dlcMods;
     }
 
-    private static List<string> GetClientModsList(ServerInstance instance)
+    private List<string> GetClientModsList(ServerInstance instance)
     {
         return instance.Mods
             .Where(m => m.IsClientSide)
@@ -650,7 +660,7 @@ public class ServerInstanceService(
             .ToList();
     }
 
-    private static string GetServerModsList(ServerInstance instance)
+    private string GetServerModsList(ServerInstance instance)
     {
         var serverMods = instance.Mods
             .Where(m => m.IsServerSide)

--- a/src/KAST.UI/Components/Pages/ServerEdit.razor
+++ b/src/KAST.UI/Components/Pages/ServerEdit.razor
@@ -129,7 +129,7 @@
             var settings = await SettingsService.GetSettingsAsync();
             _serversDirectory = settings.ServersDirectory;
             _instance.Name = $"Server-{DateTime.UtcNow:yyyyMMdd-HHmmss}";
-            _instance.InstallPath = Path.Combine(_serversDirectory, _instance.Name);
+            _instance.InstallPath = BuildInstallPath(_serversDirectory, _instance.Name);
             _serverConfig.Hostname = _instance.Name;
         }
 
@@ -141,7 +141,19 @@
     private void OnNameChanged()
     {
         if (_isNew && !string.IsNullOrWhiteSpace(_instance.Name))
-            _instance.InstallPath = Path.Combine(_serversDirectory, _instance.Name);
+            _instance.InstallPath = BuildInstallPath(_serversDirectory, _instance.Name);
+    }
+
+    private static string BuildInstallPath(string serversDirectory, string serverName)
+    {
+        var safeName = serverName.Trim();
+        foreach (var invalidChar in Path.GetInvalidFileNameChars())
+            safeName = safeName.Replace(invalidChar, '_');
+        safeName = safeName
+            .Replace(Path.DirectorySeparatorChar, '_')
+            .Replace(Path.AltDirectorySeparatorChar, '_');
+
+        return Path.Join(serversDirectory, string.IsNullOrWhiteSpace(safeName) ? "Server" : safeName);
     }
 
     private void OnServerConfigChanged() => _serverCfgRaw = ConfigService.SerializeServerConfig(_serverConfig);

--- a/src/KAST.UI/Components/Pages/ServerEditTabs/ModsTab.razor
+++ b/src/KAST.UI/Components/Pages/ServerEditTabs/ModsTab.razor
@@ -13,6 +13,20 @@
                   Variant="Variant.Outlined"
                   Style="max-width:260px;" />
     <MudSpacer />
+    <MudButton StartIcon="@Icons.Material.Filled.RemoveCircleOutline"
+               Color="Color.Default" Variant="Variant.Outlined"
+               Size="Size.Small"
+               Disabled="@(!Instance.Mods.Any())"
+               OnClick="UnloadAllMods">
+        Unload All
+    </MudButton>
+    <MudButton StartIcon="@Icons.Material.Filled.DoneAll"
+               Color="Color.Info" Variant="Variant.Outlined"
+               Size="Size.Small"
+               Disabled="@(!UnassignedMods.Any())"
+               OnClick="LoadAllAvailableMods">
+        Load All
+    </MudButton>
     <MudButton StartIcon="@Icons.Material.Filled.PlaylistAdd"
                Color="Color.Secondary" Variant="Variant.Outlined"
                Size="Size.Small"
@@ -135,18 +149,18 @@
                 <MudCheckBox T="bool?" Value="@GetPresetSelectAllState()"
                              ValueChanged="@ToggleSelectAllPresetMods"
                              Dense="true" />
-                <MudText Typo="Typo.caption" Color="Color.Secondary">Select all new</MudText>
+                <MudText Typo="Typo.caption" Color="Color.Secondary">Select all preset mods</MudText>
             </div>
 
             <div style="max-height:260px; overflow-y:auto;">
                 @foreach (var (wid, dname) in _parsedPresetMods)
                 {
+                    bool alreadyClient = Instance.Mods.Any(m => m.IsClientSide && m.SteamMod?.WorkshopId == wid);
                     bool alreadyIn = Instance.Mods.Any(m => m.SteamMod?.WorkshopId == wid);
-                    <div class="d-flex align-center gap-1 py-1" style="@(alreadyIn ? "opacity:.55;" : "")">
+                    <div class="d-flex align-center gap-1 py-1" style="@(alreadyClient ? "opacity:.75;" : "")">
                         <MudCheckBox T="bool"
                                      Value="@(_presetSelectedIds.Contains(wid))"
                                      ValueChanged="@((v) => TogglePresetMod(wid, v))"
-                                     Disabled="@alreadyIn"
                                      Dense="true" />
                         <MudIcon Icon="@Icons.Material.Filled.Extension" Size="Size.Small"
                                  Style="opacity:.4; flex-shrink:0;" />
@@ -155,7 +169,7 @@
                         @if (alreadyIn)
                         {
                             <MudChip T="string" Size="Size.Small" Color="Color.Info"
-                                     Variant="Variant.Text">in instance</MudChip>
+                                     Variant="Variant.Text">loaded</MudChip>
                         }
                     </div>
                 }
@@ -175,9 +189,9 @@
     <DialogActions>
         <MudButton OnClick="ClosePresetImportDialog" Disabled="@_isImportingPreset">Cancel</MudButton>
         <MudButton Color="Color.Primary" Variant="Variant.Filled"
-                   Disabled="@(_presetSelectedIds.Count == 0 || _isImportingPreset)"
+                   Disabled="@(_parsedPresetMods.Count == 0 || _isImportingPreset)"
                    OnClick="ImportPresetToClient">
-            Add @_presetSelectedIds.Count mod(s)
+            Replace Clientside
         </MudButton>
     </DialogActions>
 </MudDialog>
@@ -324,6 +338,24 @@
         ReindexMods();
     }
 
+    private async Task UnloadAllMods()
+    {
+        foreach (var modId in Instance.Mods.Select(m => m.SteamModId).ToList())
+            await RemoveMod(modId);
+
+        BuildDragItems();
+        StateHasChanged();
+    }
+
+    private async Task LoadAllAvailableMods()
+    {
+        foreach (var mod in UnassignedMods.OrderBy(m => m.Name).ToList())
+            await AddMod(mod.Id, "client");
+
+        BuildDragItems();
+        StateHasChanged();
+    }
+
     private void ReindexMods()
     {
         int wi = 0; foreach (var m in Instance.Mods.Where(m => !m.IsClientSide && !m.IsServerSide).OrderBy(m => m.LoadOrder)) m.LoadOrder = wi++;
@@ -376,9 +408,7 @@
             _parsedPresetMods.Add((wid, displayName));
         }
 
-        _presetSelectedIds = [.. _parsedPresetMods
-            .Where(p => !Instance.Mods.Any(m => m.SteamMod?.WorkshopId == p.WorkshopId))
-            .Select(p => p.WorkshopId)];
+        _presetSelectedIds = [.. _parsedPresetMods.Select(p => p.WorkshopId)];
 
         StateHasChanged();
     }
@@ -391,69 +421,123 @@
 
     private bool? GetPresetSelectAllState()
     {
-        var newIds = _parsedPresetMods
-            .Where(p => !Instance.Mods.Any(m => m.SteamMod?.WorkshopId == p.WorkshopId))
-            .Select(p => p.WorkshopId)
-            .ToList();
-        if (newIds.Count == 0) return false;
-        int selected = newIds.Count(id => _presetSelectedIds.Contains(id));
+        var presetIds = _parsedPresetMods.Select(p => p.WorkshopId).ToList();
+        if (presetIds.Count == 0) return false;
+        int selected = presetIds.Count(id => _presetSelectedIds.Contains(id));
         if (selected == 0) return false;
-        return selected == newIds.Count ? true : null;
+        return selected == presetIds.Count ? true : null;
     }
 
     private void ToggleSelectAllPresetMods(bool? value)
     {
-        var newIds = _parsedPresetMods
-            .Where(p => !Instance.Mods.Any(m => m.SteamMod?.WorkshopId == p.WorkshopId))
-            .Select(p => p.WorkshopId);
+        var presetIds = _parsedPresetMods.Select(p => p.WorkshopId);
         if (value == true)
-            foreach (var id in newIds) _presetSelectedIds.Add(id);
+            foreach (var id in presetIds) _presetSelectedIds.Add(id);
         else
-            foreach (var id in newIds) _presetSelectedIds.Remove(id);
+            foreach (var id in presetIds) _presetSelectedIds.Remove(id);
     }
 
     private async Task ImportPresetToClient()
     {
         _isImportingPreset = true;
-        _presetImportTotal = _presetSelectedIds.Count;
+        var selectedPresetMods = _parsedPresetMods
+            .Where(p => _presetSelectedIds.Contains(p.WorkshopId))
+            .GroupBy(p => p.WorkshopId)
+            .Select(g => g.First())
+            .ToList();
+        var selectedWorkshopIds = selectedPresetMods
+            .Select(p => p.WorkshopId)
+            .ToHashSet();
+        var clientsToUnload = Instance.Mods
+            .Where(m => m.IsClientSide && (m.SteamMod == null || !selectedWorkshopIds.Contains(m.SteamMod.WorkshopId)))
+            .ToList();
+
+        _presetImportTotal = selectedPresetMods.Count + clientsToUnload.Count;
         _presetImportDone = 0;
         StateHasChanged();
 
-        var existingWorkshopIds = Instance.Mods
-            .Where(m => m.SteamMod != null)
-            .Select(m => m.SteamMod!.WorkshopId)
-            .ToHashSet();
+        var desiredClientMods = new List<SteamMod>();
 
-        foreach (var (workshopId, _) in _parsedPresetMods.Where(p => _presetSelectedIds.Contains(p.WorkshopId)))
+        foreach (var (workshopId, _) in selectedPresetMods)
         {
             try
             {
-                var mod = await ModService.AddWorkshopModAsync(workshopId);
+                var existingMod = Instance.Mods
+                    .FirstOrDefault(m => m.SteamMod?.WorkshopId == workshopId)
+                    ?.SteamMod;
+                var mod = existingMod ?? await ModService.AddWorkshopModAsync(workshopId);
 
                 if (!_availableMods.Any(m => m.Id == mod.Id))
                     _availableMods.Add(mod);
 
-                if (!existingWorkshopIds.Contains(workshopId))
-                {
-                    if (!IsNew)
-                        await ServerService.AddModToInstanceAsync(Instance.Id, mod.Id,
-                            isClientSide: true, isServerSide: false);
-
-                    Instance.Mods.Add(new ServerInstanceMod
-                    {
-                        SteamModId   = mod.Id,
-                        SteamMod     = mod,
-                        IsClientSide = true,
-                        IsServerSide = false,
-                        LoadOrder    = Instance.Mods.Count
-                    });
-                    existingWorkshopIds.Add(workshopId);
-                }
+                desiredClientMods.Add(mod);
             }
             catch { /* skip mods that fail to resolve */ }
 
             _presetImportDone++;
             StateHasChanged();
+        }
+
+        foreach (var clientMod in clientsToUnload)
+        {
+            if (clientMod.IsServerSide)
+            {
+                clientMod.IsClientSide = false;
+                if (!IsNew)
+                    await ServerService.UpdateModFlagsAsync(
+                        Instance.Id,
+                        clientMod.SteamModId,
+                        isClientSide: false,
+                        isServerSide: true);
+            }
+            else
+            {
+                await RemoveMod(clientMod.SteamModId);
+            }
+
+            _presetImportDone++;
+            StateHasChanged();
+        }
+
+        for (var index = 0; index < desiredClientMods.Count; index++)
+        {
+            var mod = desiredClientMods[index];
+            var existingLink = Instance.Mods.FirstOrDefault(m => m.SteamModId == mod.Id);
+            if (existingLink == null)
+            {
+                if (!IsNew)
+                    await ServerService.AddModToInstanceAsync(
+                        Instance.Id,
+                        mod.Id,
+                        index,
+                        isClientSide: true,
+                        isServerSide: false);
+
+                Instance.Mods.Add(new ServerInstanceMod
+                {
+                    SteamModId   = mod.Id,
+                    SteamMod     = mod,
+                    IsClientSide = true,
+                    IsServerSide = false,
+                    LoadOrder    = index
+                });
+            }
+            else
+            {
+                existingLink.IsClientSide = true;
+                existingLink.IsServerSide = false;
+                existingLink.LoadOrder = index;
+
+                if (!IsNew)
+                {
+                    await ServerService.UpdateModFlagsAsync(
+                        Instance.Id,
+                        mod.Id,
+                        isClientSide: true,
+                        isServerSide: false);
+                    await ServerService.UpdateModLoadOrderAsync(Instance.Id, mod.Id, index);
+                }
+            }
         }
 
         ReindexMods();

--- a/src/KAST.UI/KAST.UI.csproj
+++ b/src/KAST.UI/KAST.UI.csproj
@@ -18,6 +18,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />

--- a/src/KAST.UI/Program.cs
+++ b/src/KAST.UI/Program.cs
@@ -15,6 +15,10 @@ using OpenTelemetry.Trace;
 using ModStatus = KAST.Core.Enums.ModStatus;
 
 var builder = WebApplication.CreateBuilder(args);
+builder.Host.UseWindowsService(options =>
+{
+    options.ServiceName = "KAST Panel";
+});
 
 // ── In-memory log capture (UI console) ──────────────────────────────────────
 var kastLogStore = new KastLogStore();
@@ -193,4 +197,3 @@ _ = Task.Run(async () =>
 });
 
 app.Run();
-

--- a/tests/KAST.Tests/ServerInstanceServiceTests.cs
+++ b/tests/KAST.Tests/ServerInstanceServiceTests.cs
@@ -200,6 +200,53 @@ public class ServerInstanceServiceTests : IDisposable
     }
 
     [Fact]
+    public void GetCommandLine_UsesAbsolutePerInstancePathsForArmaPathArguments()
+    {
+        var relativeInstallPath = Path.Combine("servers", "Server-20260528-202725");
+        var instance = new ServerInstance
+        {
+            Id = 2,
+            InstallPath = relativeInstallPath,
+            Port = 2302,
+            ServerCfgContent = "BattlEye = 0;",
+            BasicCfgContent = """
+                              // KAST Basic Server Configuration
+
+                              viewDistance = 2000;
+                              terrainGrid = 25;
+                              MaxMsgSend = 128;
+                              MaxSizeGuaranteed = 512;
+                              MaxSizeNonguaranteed = 256;
+                              MinBandwidth = 131072;
+                              MaxBandwidth = 10000000000;
+                              MinErrorToSend = 0.001;
+                              MinErrorToSendNear = 0.01;
+                              MaxCustomFileSize = 1024;
+                              class sockets
+                              {
+                                  maxPacketSize = 1400;
+                              };
+                              """
+        };
+
+        var commandLine = _sut.GetCommandLine(instance);
+
+        var fullInstallPath = Path.GetFullPath(relativeInstallPath);
+        var configDir = Path.Combine(fullInstallPath, "KAST", instance.Id.ToString());
+        var executableName = OperatingSystem.IsWindows()
+            ? "arma3server_x64.exe"
+            : "arma3server_x64";
+
+        Assert.StartsWith(Path.Combine(fullInstallPath, executableName), commandLine);
+        if (!OperatingSystem.IsLinux())
+            Assert.Contains($"\"-profiles={configDir}\"", commandLine);
+        Assert.Contains($"\"-config={Path.Combine(configDir, "server.cfg")}\"", commandLine);
+        Assert.Contains($"\"-cfg={Path.Combine(configDir, "basic.cfg")}\"", commandLine);
+        Assert.DoesNotContain($"-config={relativeInstallPath}", commandLine);
+        Assert.DoesNotContain($"-cfg={relativeInstallPath}", commandLine);
+    }
+
+    [Fact]
     public async Task StartInstance_ProcessFails_SetsCrashedStatus()
     {
         var instance = await SeedInstanceAsync();

--- a/tests/KAST.Tests/ServerInstanceServiceTests.cs
+++ b/tests/KAST.Tests/ServerInstanceServiceTests.cs
@@ -209,6 +209,7 @@ public class ServerInstanceServiceTests : IDisposable
             InstallPath = relativeInstallPath,
             Port = 2302,
             ServerCfgContent = "BattlEye = 0;",
+            ArmaProfileContent = "class DifficultyPresets {};",
             BasicCfgContent = """
                               // KAST Basic Server Configuration
 
@@ -231,7 +232,7 @@ public class ServerInstanceServiceTests : IDisposable
 
         var commandLine = _sut.GetCommandLine(instance);
 
-        var fullInstallPath = Path.GetFullPath(relativeInstallPath);
+        var fullInstallPath = Path.GetFullPath(relativeInstallPath, AppContext.BaseDirectory);
         var configDir = Path.Combine(fullInstallPath, "KAST", instance.Id.ToString());
         var executableName = OperatingSystem.IsWindows()
             ? "arma3server_x64.exe"


### PR DESCRIPTION
<!--
  PR TITLE — must follow Conventional Commits:
    feat: add server scheduling
    fix: steam reconnect loop
    perf(db): index ServerInstance by status
    chore: bump SteamKit2 to 3.1.0
    feat!: breaking change (bumps major version)

  Branch rules:
    feature/<name>  →  target: develop
    hotfix/<name>   →  target: main  (then a second PR into develop)
    chore/...       →  target: develop
-->

## Summary

<!-- What does this PR do? One paragraph is enough. -->
Fixes incorrect pathing parameters causing configuration files to be ignored when creating a new server. Also fixes instanceId not being accessed.
Closes #37 

---

## Type of Change

<!-- Check all that apply -->

- [ ] `feat` — new feature
- [X] `fix` — bug fix
- [ ] `perf` — performance improvement
- [ ] `refactor` — code restructure, no behaviour change
- [ ] `docs` — documentation only
- [ ] `chore` / `ci` — build, tooling, dependencies
- [ ] **Breaking change** — existing behaviour changes (add `!` to the PR title type)

---

## What Changed

<!-- Bullet points are fine. Focus on the *why*, not just the *what*. -->
- ServerInstanceService.cs now uses GetInstanceConfigDirectory() and GetModsDirectory() as opposed to manual path building

---

## Testing

<!-- How did you verify this works? Which tests cover it? -->

- [X] Existing tests pass (`dotnet test`)
- [X] New tests added for the changed behaviour
- [X] Manually tested — describe below if relevant
Tested manually with a custom build of KAST
---

## Checklist

- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [X] Targets the correct branch (`develop` for features, `main` for hotfixes)
- [ ] No unrelated changes mixed in (whitespace, refactors, unrelated fixes)
- [X] EF Core migration included if any entity model changed
- [X] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

