### PR TITLE
feat: sanitize filesystem paths across UI, API, and service logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,40 +245,54 @@ jobs:
           pattern: nightly-*
           merge-multiple: true
 
-      - name: Delete previous nightly release + tag
+      - name: Move nightly tag to current commit
         run: |
-          gh release delete nightly --yes --cleanup-tag || true
-          git push origin :refs/tags/nightly            || true
+          git tag -f nightly "${GITHUB_SHA}"
+          git push origin refs/tags/nightly --force
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Create nightly pre-release
-        uses: softprops/action-gh-release@v3
-        with:
-          tag_name:    nightly
-          name:        "Nightly – ${{ steps.version.outputs.version }}"
-          prerelease:  true
-          make_latest: false
-          body: |
-            🌙 **Automated nightly build** from the `develop` branch.
+      - name: Create or update nightly pre-release
+        run: |
+          cat > NIGHTLY_RELEASE_BODY.md <<EOF
+          🌙 **Automated nightly build** from the `develop` branch.
 
-            | | |
-            |---|---|
-            | **Version** | `${{ steps.version.outputs.version }}` |
-            | **Commit** | [`${{ github.sha }}`](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}) |
-            | **Date** | `${{ steps.version.outputs.date }}` |
+          | | |
+          |---|---|
+          | **Version** | `${{ steps.version.outputs.version }}` |
+          | **Commit** | [`${{ github.sha }}`](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}) |
+          | **Date** | `${{ steps.version.outputs.date }}` |
 
-            > ⚠️ Nightly builds are automatically generated from the latest development code and may be unstable.
-            > Use [tagged releases](../../releases/latest) for production deployments.
+          > ⚠️ Nightly builds are automatically generated from the latest development code and may be unstable.
+          > Use [tagged releases](../../releases/latest) for production deployments.
 
-            ### Downloads
-            | Platform | File |
-            |---|---|
-            | Linux x64 | `kast-linux-x64-nightly.tar.gz` |
-            | Linux arm64 | `kast-linux-arm64-nightly.tar.gz` |
-            | Windows x64 | `kast-win-x64-nightly.zip` |
-            | Docker | `ghcr.io/${{ github.repository_owner }}/kast:nightly` |
-          files: |
-            kast-linux-x64-nightly.tar.gz
-            kast-linux-arm64-nightly.tar.gz
-            kast-win-x64-nightly.zip
+          ### Downloads
+          | Platform | File |
+          |---|---|
+          | Linux x64 | `kast-linux-x64-nightly.tar.gz` |
+          | Linux arm64 | `kast-linux-arm64-nightly.tar.gz` |
+          | Windows x64 | `kast-win-x64-nightly.zip` |
+          | Docker | `ghcr.io/${{ github.repository_owner }}/kast:nightly` |
+          EOF
+
+          if gh release view nightly >/dev/null 2>&1; then
+            gh release edit nightly \
+              --title "Nightly - ${{ steps.version.outputs.version }}" \
+              --notes-file NIGHTLY_RELEASE_BODY.md \
+              --prerelease
+            gh release upload nightly \
+              kast-linux-x64-nightly.tar.gz \
+              kast-linux-arm64-nightly.tar.gz \
+              kast-win-x64-nightly.zip \
+              --clobber
+          else
+            gh release create nightly \
+              kast-linux-x64-nightly.tar.gz \
+              kast-linux-arm64-nightly.tar.gz \
+              kast-win-x64-nightly.zip \
+              --title "Nightly - ${{ steps.version.outputs.version }}" \
+              --notes-file NIGHTLY_RELEASE_BODY.md \
+              --prerelease
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -486,3 +486,6 @@ $RECYCLE.BIN/
 
 # Visual Studio Code files for those working on multiple tools
 .vscode
+
+# Graphify output
+graphify-out/

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,6 +13,8 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.8" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="MinVer" Version="7.0.0" />

--- a/src/KAST.Core/Interfaces/IOutputSanitizer.cs
+++ b/src/KAST.Core/Interfaces/IOutputSanitizer.cs
@@ -1,0 +1,14 @@
+namespace KAST.Core.Interfaces;
+
+/// <summary>
+/// Sanitizes text that can leave internal boundaries such as UI, APIs, logs,
+/// telemetry, SignalR messages, and install status state.
+/// </summary>
+public interface IOutputSanitizer
+{
+    string Sanitize(string? value);
+
+    string ToDisplayPath(string? path);
+
+    string SanitizeException(Exception exception);
+}

--- a/src/KAST.Infrastructure/DependencyInjection.cs
+++ b/src/KAST.Infrastructure/DependencyInjection.cs
@@ -5,6 +5,7 @@ using KAST.Infrastructure.Services.Content;
 using KAST.Infrastructure.Steam;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace KAST.Infrastructure;
 
@@ -17,10 +18,12 @@ public static class DependencyInjection
                 o => o.UseQuerySplittingBehavior(QuerySplittingBehavior.SplitQuery)));
 
         // Steam services
+        services.TryAddSingleton<IOutputSanitizer, OutputSanitizer>();
         services.AddSingleton<ISteamService>(sp =>
         {
             var logger = sp.GetRequiredService<Microsoft.Extensions.Logging.ILogger<SteamClientService>>();
-            return new SteamClientService(logger);
+            var sanitizer = sp.GetRequiredService<IOutputSanitizer>();
+            return new SteamClientService(logger, sanitizer);
         });
 
         services.AddSingleton<IProcessManagerService, ProcessManagerService>();

--- a/src/KAST.Infrastructure/KAST.Infrastructure.csproj
+++ b/src/KAST.Infrastructure/KAST.Infrastructure.csproj
@@ -9,6 +9,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="SteamKit2" />
   </ItemGroup>

--- a/src/KAST.Infrastructure/Services/Content/ContentOrchestrator.cs
+++ b/src/KAST.Infrastructure/Services/Content/ContentOrchestrator.cs
@@ -73,7 +73,7 @@ public class ContentOrchestrator(
         activity?.SetTag("content.queued", true);
         activity?.SetTag("content.steps",  steps.Count);
 
-        _ = Task.Run(() => RunAsync(key, request, state, cts.Token), cts.Token);
+        _ = Task.Run(() => RunAsync(key, request, state, cts.Token));
         return state;
     }
 
@@ -121,7 +121,7 @@ public class ContentOrchestrator(
         activity?.SetTag("content.queued", true);
         activity?.SetTag("content.steps",  steps.Count);
 
-        _ = Task.Run(() => RunAsync(key, request, state, cts.Token, onComplete, onError), cts.Token);
+        _ = Task.Run(() => RunAsync(key, request, state, cts.Token, onComplete, onError));
         return state;
     }
 

--- a/src/KAST.Infrastructure/Services/Content/ContentOrchestrator.cs
+++ b/src/KAST.Infrastructure/Services/Content/ContentOrchestrator.cs
@@ -19,7 +19,8 @@ public class ContentOrchestrator(
     IServiceScopeFactory scopeFactory,
     ContentProgressTracker tracker,
     IEnumerable<IContentInstaller> installers,
-    ILogger<ContentOrchestrator> logger) : IContentOrchestrator
+    ILogger<ContentOrchestrator> logger,
+    IOutputSanitizer sanitizer) : IContentOrchestrator
 {
     private readonly ConcurrentDictionary<string, CancellationTokenSource> _active = new();
     private readonly Dictionary<ContentType, IContentInstaller> _installers =
@@ -39,7 +40,6 @@ public class ContentOrchestrator(
             "kast.content.queued", ActivityKind.Internal);
         activity?.SetTag("content.key",             key);
         activity?.SetTag("content.type",            ContentType.Server.ToString());
-        activity?.SetTag("content.destination",     installPath);
         activity?.SetTag("content.instance_id",     instanceId);
         activity?.SetTag("content.instance_name",   instance.Name);
         activity?.SetTag("content.parallel_workers", maxParallelDownloads);
@@ -90,12 +90,9 @@ public class ContentOrchestrator(
             "kast.content.queued", ActivityKind.Internal);
         activity?.SetTag("content.key",         key);
         activity?.SetTag("content.type",        type.ToString());
-        activity?.SetTag("content.destination",  destinationPath);
         activity?.SetTag("content.mod_id",      modId);
         if (workshopId != 0)
             activity?.SetTag("content.workshop_id", workshopId);
-        if (sourcePath is not null)
-            activity?.SetTag("content.source_path", sourcePath);
 
         if (_active.ContainsKey(key))
         {
@@ -158,7 +155,6 @@ public class ContentOrchestrator(
             "kast.content.install", ActivityKind.Internal);
         activity?.SetTag("content.key",         key);
         activity?.SetTag("content.type",        request.Type.ToString());
-        activity?.SetTag("content.destination",  request.DestinationPath);
         activity?.SetTag("content.steps",        state.Steps.Count);
         if (request.Type == ContentType.Server)
             activity?.SetTag("content.instance_id", request.ServerInstanceId);
@@ -191,25 +187,25 @@ public class ContentOrchestrator(
         {
             // Spurious TaskCanceledException from an HTTP timeout or SteamKit2 internals.
             // Treat it as a real error so the user sees a meaningful message.
-            logger.LogWarning(oce, "Spurious cancellation in content install {Key} (not user-requested) — treating as error", key);
-            activity?.SetStatus(ActivityStatusCode.Error, oce.Message);
+            var safeMessage = sanitizer.Sanitize(oce.Message);
+            activity?.SetStatus(ActivityStatusCode.Error, safeMessage);
             activity?.AddEvent(new ActivityEvent("exception", tags: new ActivityTagsCollection
             {
                 ["exception.type"]    = oce.GetType().FullName ?? oce.GetType().Name,
-                ["exception.message"] = oce.Message
+                ["exception.message"] = safeMessage
             }));
             await HandleErrorAsync(key, request, state,
-                new IOException($"Network timeout or transient failure during download. Details: {oce.Message}", oce),
+                new IOException($"Network timeout or transient failure during download. Details: {safeMessage}", oce),
                 onError);
         }
         catch (Exception ex)
         {
-            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            var safeMessage = sanitizer.Sanitize(ex.Message);
+            activity?.SetStatus(ActivityStatusCode.Error, safeMessage);
             activity?.AddEvent(new ActivityEvent("exception", tags: new ActivityTagsCollection
             {
-                ["exception.type"]       = ex.GetType().FullName ?? ex.GetType().Name,
-                ["exception.message"]    = ex.Message,
-                ["exception.stacktrace"] = ex.StackTrace ?? string.Empty
+                ["exception.type"]    = ex.GetType().FullName ?? ex.GetType().Name,
+                ["exception.message"] = safeMessage
             }));
             await HandleErrorAsync(key, request, state, ex, onError);
         }
@@ -265,19 +261,20 @@ public class ContentOrchestrator(
     private async Task HandleErrorAsync(string key, ContentInstallRequest request, ContentInstallState state, Exception ex,
         Func<IServiceProvider, ContentInstallState, Exception, Task>? onError)
     {
+        var safeMessage = sanitizer.Sanitize(ex.Message);
         logger.LogError(ex, "Content install failed: {Key}", key);
-        state.AddLog($"ERROR: {ex.Message}");
+        state.AddLog($"ERROR: {safeMessage}");
         state.IsDownloading = false;
-        state.ErrorMessage = ex.Message;
+        state.ErrorMessage = safeMessage;
 
         if (state.CurrentStep is { Status: ContentStepStatus.InProgress })
-            state.FailStep(state.CurrentStepIndex, ex.Message);
+            state.FailStep(state.CurrentStepIndex, safeMessage);
         else
         {
             // Error occurred before any step was started (e.g. Steam connection failure)
             var firstPending = state.Steps.FindIndex(s => s.Status == ContentStepStatus.Pending);
             if (firstPending >= 0)
-                state.FailStep(firstPending, ex.Message);
+                state.FailStep(firstPending, safeMessage);
         }
 
         await HandleErrorCallbackAsync(onError, state, ex);

--- a/src/KAST.Infrastructure/Services/Content/LocalModInstaller.cs
+++ b/src/KAST.Infrastructure/Services/Content/LocalModInstaller.cs
@@ -7,7 +7,7 @@ namespace KAST.Infrastructure.Services.Content;
 /// <summary>
 /// Installs a local mod: extracts a ZIP or validates an existing folder.
 /// </summary>
-public class LocalModInstaller(IFileSystemService fs) : IContentInstaller
+public class LocalModInstaller(IFileSystemService fs, IOutputSanitizer sanitizer) : IContentInstaller
 {
     public ContentType Type => ContentType.LocalMod;
 
@@ -17,9 +17,9 @@ public class LocalModInstaller(IFileSystemService fs) : IContentInstaller
         var steps = new List<ContentStep>();
 
         if (isZip)
-            steps.Add(new ContentStep { Name = "Extract archive", Detail = Path.GetFileName(request.SourcePath) });
+            steps.Add(new ContentStep { Name = "Extract archive", Detail = $"{sanitizer.ToDisplayPath(request.SourcePath)} → {sanitizer.ToDisplayPath(request.DestinationPath)}" });
 
-        steps.Add(new ContentStep { Name = "Calculate size", Detail = request.DestinationPath });
+        steps.Add(new ContentStep { Name = "Calculate size", Detail = sanitizer.ToDisplayPath(request.DestinationPath) });
 
         return steps;
     }
@@ -32,7 +32,7 @@ public class LocalModInstaller(IFileSystemService fs) : IContentInstaller
         if (isZip)
         {
             state.BeginStep(stepIdx);
-            state.AddLog($"Extracting {Path.GetFileName(request.SourcePath)} → {request.DestinationPath}");
+            state.AddLog($"Extracting {sanitizer.ToDisplayPath(request.SourcePath)} to {sanitizer.ToDisplayPath(request.DestinationPath)}");
 
             var currentStep = stepIdx;
             var progress = new Progress<double>(pct => state.SetStepProgress(currentStep, pct));
@@ -44,7 +44,7 @@ public class LocalModInstaller(IFileSystemService fs) : IContentInstaller
         }
 
         state.BeginStep(stepIdx);
-        state.AddLog("Calculating size on disk...");
+        state.AddLog($"Calculating size on disk for {sanitizer.ToDisplayPath(request.DestinationPath)}...");
 
         long size = fs.GetDirectorySize(request.DestinationPath);
         state.AddLog($"Size: {size / (1024.0 * 1024.0):F1} MiB");
@@ -56,7 +56,8 @@ public class LocalModInstaller(IFileSystemService fs) : IContentInstaller
     {
         var results = new List<ContentValidationResult>();
         bool exists = Directory.Exists(request.DestinationPath);
-        results.Add(new("Mod directory", exists, request.DestinationPath));
+        var displayPath = sanitizer.ToDisplayPath(request.DestinationPath);
+        results.Add(new("Mod directory", exists, exists ? displayPath : $"Missing: {displayPath}"));
 
         if (!exists) return results;
 

--- a/src/KAST.Infrastructure/Services/Content/ServerInstaller.cs
+++ b/src/KAST.Infrastructure/Services/Content/ServerInstaller.cs
@@ -13,7 +13,7 @@ namespace KAST.Infrastructure.Services.Content;
 /// <summary>
 /// Installs the Arma 3 dedicated server + Creator DLC depots via SteamKit2.
 /// </summary>
-public class ServerInstaller(ISteamService steam, IFileSystemService fs, IHttpClientFactory httpClientFactory, ILogger<ServerInstaller> logger) : IContentInstaller
+public class ServerInstaller(ISteamService steam, IFileSystemService fs, IHttpClientFactory httpClientFactory, ILogger<ServerInstaller> logger, IOutputSanitizer sanitizer) : IContentInstaller
 {
     public const uint Arma3ServerAppId = 233780;
     private const string CreatorDlcBranch = "creatordlc";
@@ -37,7 +37,7 @@ public class ServerInstaller(ISteamService steam, IFileSystemService fs, IHttpCl
     {
         var steps = new List<ContentStep>
         {
-            new() { Name = "Arma 3 Dedicated Server", Detail = "branch: public" }
+            new() { Name = "Arma 3 Dedicated Server", Detail = $"branch: public → {sanitizer.ToDisplayPath(request.DestinationPath)}" }
         };
 
         if (request.Instance is null) return steps;
@@ -83,11 +83,12 @@ public class ServerInstaller(ISteamService steam, IFileSystemService fs, IHttpCl
                 throw new InvalidOperationException("Failed to connect to Steam.");
 
             state.AddLog(steam.IsAuthenticated ? $"Signed in as {steam.CurrentUsername}." : "Connected anonymously.");
+            state.AddLog($"Install target: {sanitizer.ToDisplayPath(request.DestinationPath)}.");
             state.AddLog($"Parallel downloads: {maxPar}.");
-            logger.LogInformation("Server install [{Instance}]: steam ready, {Auth}, {Par} workers, dest={Path}",
+            logger.LogInformation("Server install [{Instance}]: steam ready, {Auth}, {Par} workers",
                 instance.Name,
                 steam.IsAuthenticated ? $"authenticated as {steam.CurrentUsername}" : "anonymous",
-                maxPar, request.DestinationPath);
+                maxPar);
 
         int stepIdx = 0;
 
@@ -166,7 +167,7 @@ public class ServerInstaller(ISteamService steam, IFileSystemService fs, IHttpCl
         }
         catch (Exception ex)
         {
-            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            activity?.SetStatus(ActivityStatusCode.Error, sanitizer.Sanitize(ex.Message));
             throw;
         }
     }
@@ -177,16 +178,17 @@ public class ServerInstaller(ISteamService steam, IFileSystemService fs, IHttpCl
         var installPath = request.DestinationPath;
 
         bool dirExists = Directory.Exists(installPath);
-        results.Add(new("Install directory", dirExists, dirExists ? installPath : "Not found"));
+        var displayPath = sanitizer.ToDisplayPath(installPath);
+        results.Add(new("Install directory", dirExists, dirExists ? displayPath : $"Not found: {displayPath}"));
 
         if (!dirExists) return results;
 
         var exeName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "arma3server_x64.exe" : "arma3server_x64";
         var exePath = Path.Combine(installPath, exeName);
-        results.Add(new("Server executable", File.Exists(exePath), exeName));
+        results.Add(new("Server executable", File.Exists(exePath), sanitizer.ToDisplayPath(exePath)));
 
         results.AddRange(new[] { "addons", "dta", "keys" }.Select(dir =>
-            new ContentValidationResult(dir, Directory.Exists(Path.Combine(installPath, dir)))));
+            new ContentValidationResult(dir, Directory.Exists(Path.Combine(installPath, dir)), sanitizer.ToDisplayPath(Path.Combine(installPath, dir)))));
 
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && File.Exists(exePath))
         {
@@ -200,7 +202,8 @@ public class ServerInstaller(ISteamService steam, IFileSystemService fs, IHttpCl
                 .Where(d => d.Enabled(request.Instance))
                 .Select(dlc => new ContentValidationResult(
                     $"{dlc.Name} ({dlc.Folder}/)",
-                    Directory.Exists(Path.Combine(installPath, dlc.Folder)))));
+                    Directory.Exists(Path.Combine(installPath, dlc.Folder)),
+                    sanitizer.ToDisplayPath(Path.Combine(installPath, dlc.Folder)))));
         }
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -214,7 +217,7 @@ public class ServerInstaller(ISteamService steam, IFileSystemService fs, IHttpCl
                 Path.Combine(sys,   "XINPUT1_3.dll"),
             }.FirstOrDefault(File.Exists);
             results.Add(new("DirectX", found is not null,
-                found ?? $"D3DX9_43.dll not found in {sys} or {sys86}"));
+                found is not null ? "Installed" : "Required DirectX files were not found"));
         }
 
         return results;
@@ -307,10 +310,9 @@ public class ServerInstaller(ISteamService steam, IFileSystemService fs, IHttpCl
                 }
                 else
                 {
-                    string sys = Environment.GetFolderPath(Environment.SpecialFolder.System);
-                    state.FailStep(stepIdx, "DXSETUP.exe reported success but D3DX9_43.dll was not found.");
-                    state.AddLog($"⚠ D3DX9_43.dll not found in {sys} after DXSETUP.exe.");
-                    logger.LogError("Server install [{Instance}]: DXSETUP.exe exited 0 but D3DX9_43.dll absent", instance.Name);
+                    state.FailStep(stepIdx, "DXSETUP.exe reported success but required DirectX files were not found.");
+                    state.AddLog("⚠ Required DirectX files were not found after DXSETUP.exe.");
+                    logger.LogError("Server install [{Instance}]: DXSETUP.exe exited 0 but required DirectX files are absent", instance.Name);
                 }
             }
             else

--- a/src/KAST.Infrastructure/Services/Content/SteamModInstaller.cs
+++ b/src/KAST.Infrastructure/Services/Content/SteamModInstaller.cs
@@ -9,14 +9,14 @@ namespace KAST.Infrastructure.Services.Content;
 /// <summary>
 /// Downloads a Steam Workshop mod via SteamKit2.
 /// </summary>
-public class SteamModInstaller(ISteamService steam, IFileSystemService fs) : IContentInstaller
+public class SteamModInstaller(ISteamService steam, IFileSystemService fs, IOutputSanitizer sanitizer) : IContentInstaller
 {
     public ContentType Type => ContentType.SteamMod;
 
     public IReadOnlyList<ContentStep> PlanSteps(ContentInstallRequest request) =>
     [
-        new ContentStep { Name = "Download from Workshop", Detail = $"ID {request.WorkshopId}" },
-        new ContentStep { Name = "Calculate size" }
+        new ContentStep { Name = "Download from Workshop", Detail = $"ID {request.WorkshopId} → {sanitizer.ToDisplayPath(request.DestinationPath)}" },
+        new ContentStep { Name = "Calculate size", Detail = sanitizer.ToDisplayPath(request.DestinationPath) }
     ];
 
     public async Task InstallAsync(ContentInstallRequest request, ContentInstallState state, CancellationToken ct)
@@ -24,12 +24,11 @@ public class SteamModInstaller(ISteamService steam, IFileSystemService fs) : ICo
         using var activity = KastActivitySources.Content.StartActivity(
             "kast.steam.mod_download", ActivityKind.Internal);
         activity?.SetTag("workshop.id",  request.WorkshopId);
-        activity?.SetTag("destination",  request.DestinationPath);
 
         try
         {
         state.BeginStep(0);
-        state.AddLog($"Downloading Workshop item {request.WorkshopId} → {request.DestinationPath}");
+        state.AddLog($"Downloading Workshop item {request.WorkshopId} to {sanitizer.ToDisplayPath(request.DestinationPath)}");
 
         if (!steam.IsConnected)
         {
@@ -57,7 +56,7 @@ public class SteamModInstaller(ISteamService steam, IFileSystemService fs) : ICo
         }
         catch (Exception ex)
         {
-            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            activity?.SetStatus(ActivityStatusCode.Error, sanitizer.Sanitize(ex.Message));
             throw;
         }
     }
@@ -66,7 +65,8 @@ public class SteamModInstaller(ISteamService steam, IFileSystemService fs) : ICo
     {
         var results = new List<ContentValidationResult>();
         bool exists = Directory.Exists(request.DestinationPath);
-        results.Add(new("Mod directory", exists, request.DestinationPath));
+        var displayPath = sanitizer.ToDisplayPath(request.DestinationPath);
+        results.Add(new("Mod directory", exists, exists ? displayPath : $"Missing: {displayPath}"));
 
         if (!exists) return results;
 

--- a/src/KAST.Infrastructure/Services/ModService.cs
+++ b/src/KAST.Infrastructure/Services/ModService.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.Logging;
 
 namespace KAST.Infrastructure.Services;
 
-public class ModService(KastDbContext db, ISteamService steamService, ISettingsService settingsService, IAppEventBroadcaster broadcaster, ILogger<ModService> logger) : IModService
+public class ModService(KastDbContext db, ISteamService steamService, ISettingsService settingsService, IAppEventBroadcaster broadcaster, ILogger<ModService> logger, IOutputSanitizer sanitizer) : IModService
 {
     public async Task<IReadOnlyList<SteamMod>> GetAllModsAsync(CancellationToken ct = default)
         => await db.Mods.AsNoTracking().OrderBy(m => m.Name).ToListAsync(ct);
@@ -65,11 +65,11 @@ public class ModService(KastDbContext db, ISteamService steamService, ISettingsS
         }
         catch (Exception ex)
         {
-            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            activity?.SetStatus(ActivityStatusCode.Error, sanitizer.Sanitize(ex.Message));
             activity?.AddEvent(new ActivityEvent("exception", tags: new ActivityTagsCollection
             {
                 ["exception.type"]    = ex.GetType().Name,
-                ["exception.message"] = ex.Message
+                ["exception.message"] = sanitizer.Sanitize(ex.Message)
             }));
             throw;
         }
@@ -80,7 +80,6 @@ public class ModService(KastDbContext db, ISteamService steamService, ISettingsS
         using var activity = KastActivitySources.Mods.StartActivity(
             "kast.mod.import_local", ActivityKind.Internal);
         activity?.SetTag("mod.name", name);
-        activity?.SetTag("mod.path", path);
 
         var isZip = path.EndsWith(".zip", StringComparison.OrdinalIgnoreCase);
         activity?.SetTag("mod.source", isZip ? "zip" : "folder");
@@ -110,8 +109,7 @@ public class ModService(KastDbContext db, ISteamService steamService, ISettingsS
         var mod = await db.Mods.FindAsync([id], ct);
         if (mod != null)
         {
-            activity?.SetTag("mod.name",       mod.Name);
-            activity?.SetTag("mod.local_path", mod.LocalPath ?? "");
+            activity?.SetTag("mod.name", mod.Name);
 
             // Delete mod files from disk
             if (!string.IsNullOrEmpty(mod.LocalPath) && Directory.Exists(mod.LocalPath))
@@ -119,16 +117,15 @@ public class ModService(KastDbContext db, ISteamService steamService, ISettingsS
                 try
                 {
                     Directory.Delete(mod.LocalPath, recursive: true);
-                    logger.LogInformation("Deleted mod files at {Path}", mod.LocalPath);
+                    logger.LogInformation("Deleted mod files for mod {Id}", mod.Id);
                 }
                 catch (Exception ex)
                 {
-                    logger.LogWarning(ex, "Failed to delete mod files at {Path}", mod.LocalPath);
+                    logger.LogWarning(ex, "Failed to delete mod files for mod {Id}", mod.Id);
                     activity?.AddEvent(new ActivityEvent("files.delete_failed", tags: new ActivityTagsCollection
                     {
-                        ["path"]              = mod.LocalPath,
                         ["exception.type"]    = ex.GetType().Name,
-                        ["exception.message"] = ex.Message
+                        ["exception.message"] = sanitizer.Sanitize(ex.Message)
                     }));
                 }
             }
@@ -194,7 +191,7 @@ public class ModService(KastDbContext db, ISteamService steamService, ISettingsS
             mod.Status = ModStatus.Error;
             mod.LocalPath = string.Empty;
             mod.SizeBytes = 0;
-            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            activity?.SetStatus(ActivityStatusCode.Error, sanitizer.Sanitize(ex.Message));
             throw;
         }
         finally
@@ -252,7 +249,7 @@ public class ModService(KastDbContext db, ISteamService steamService, ISettingsS
             logger.LogError(ex, "Update failed for mod {Id} (WorkshopId={WorkshopId})", id, mod.WorkshopId);
             mod.Status = ModStatus.Error;
             mod.SizeBytes = 0;
-            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            activity?.SetStatus(ActivityStatusCode.Error, sanitizer.Sanitize(ex.Message));
             throw;
         }
         finally

--- a/src/KAST.Infrastructure/Services/OutputSanitizer.cs
+++ b/src/KAST.Infrastructure/Services/OutputSanitizer.cs
@@ -1,0 +1,291 @@
+using System.Text.RegularExpressions;
+using KAST.Core.Interfaces;
+
+namespace KAST.Infrastructure.Services;
+
+public sealed partial class OutputSanitizer : IOutputSanitizer
+{
+    private const string UnknownPath = "unknown";
+    private readonly Func<string, string?> _resolveFinalPath;
+    private readonly IReadOnlyList<NormalizedVirtualPathRoot> _virtualRoots;
+
+    public OutputSanitizer()
+        : this(Array.Empty<VirtualPathRoot>())
+    {
+    }
+
+    public OutputSanitizer(params string[] roots)
+        : this(roots.Select(root => new VirtualPathRoot(root, null)).ToArray())
+    {
+    }
+
+    public OutputSanitizer(params VirtualPathRoot[] roots)
+        : this(TryResolveFinalPath, roots)
+    {
+    }
+
+    public OutputSanitizer(Func<string, string?> resolveFinalPath, params VirtualPathRoot[] roots)
+    {
+        _resolveFinalPath = resolveFinalPath;
+        _virtualRoots = roots
+            .Where(root => !string.IsNullOrWhiteSpace(root.PhysicalPath))
+            .Select(root =>
+            {
+                var physicalPath = NormalizePath(root.PhysicalPath);
+                return new NormalizedVirtualPathRoot(
+                    physicalPath,
+                    NormalizeVirtualPath(root.VirtualPath),
+                    TryResolvePath(resolveFinalPath, physicalPath));
+            })
+            .Where(root => !string.IsNullOrWhiteSpace(root.PhysicalPath))
+            .DistinctBy(root => root.PhysicalPath, StringComparer.OrdinalIgnoreCase)
+            .OrderByDescending(root => root.PhysicalPath.Length)
+            .ToArray();
+    }
+
+    public string Sanitize(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return string.Empty;
+
+        var sanitized = value;
+        sanitized = FileUriRegex().Replace(sanitized, match => ToDisplayPath(match.Value));
+        sanitized = WindowsStackTracePathRegex().Replace(sanitized, match => $" in {ToDisplayPath(match.Groups["path"].Value)}:line ");
+        sanitized = WindowsDrivePathRegex().Replace(sanitized, match => ToDisplayPath(match.Value));
+        sanitized = UncPathRegex().Replace(sanitized, match => ToDisplayPath(match.Value));
+        sanitized = PosixPathRegex().Replace(sanitized, match => ToDisplayPath(match.Value));
+        sanitized = HomePathRegex().Replace(sanitized, match => ToDisplayPath(match.Value));
+
+        return sanitized;
+    }
+
+    public string ToDisplayPath(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return string.Empty;
+
+        var normalized = NormalizePath(path);
+        var segments = GetPathSegments(normalized);
+        if (segments.Length == 0)
+            return UnknownPath;
+
+        var virtualPath = TryToVirtualPath(normalized);
+        if (!string.IsNullOrWhiteSpace(virtualPath))
+            return virtualPath;
+
+        return IsRootedPath(path) ? segments[^1] : string.Join('/', segments);
+    }
+
+    public string SanitizeException(Exception exception)
+    {
+        var message = string.IsNullOrWhiteSpace(exception.Message)
+            ? exception.GetType().Name
+            : exception.Message;
+
+        return $"{exception.GetType().Name}: {Sanitize(message)}";
+    }
+
+    private static string NormalizePath(string value) =>
+        Canonicalize(NormalizeSeparators(value.Trim()));
+
+    private static string NormalizeSeparators(string value)
+    {
+        if (Uri.TryCreate(value, UriKind.Absolute, out var uri) && uri.IsFile)
+            value = uri.LocalPath;
+
+        value = value.Replace('\\', '/');
+        return value.StartsWith("~/", StringComparison.Ordinal) ? value[2..].Trim('/') : value.Trim('/');
+    }
+
+    private static string Canonicalize(string value)
+    {
+        var segments = new List<string>();
+        foreach (var segment in value.Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            if (segment is "." or "~")
+                continue;
+
+            if (segment == "..")
+            {
+                if (segments.Count > 0 && segments[^1] != "..")
+                    segments.RemoveAt(segments.Count - 1);
+                else
+                    segments.Add(segment);
+                continue;
+            }
+
+            segments.Add(segment);
+        }
+
+        return string.Join('/', segments);
+    }
+
+    private static string[] GetPathSegments(string value) =>
+        value.Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Where(segment =>
+                !segment.EndsWith(':') &&
+                segment is not "." and not "~" and not ".." &&
+                !segment.Equals(".KAST_DATA", StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+
+    private string? TryToVirtualPath(string normalizedPath)
+    {
+        foreach (var root in _virtualRoots)
+        {
+            if (!IsUnderRoot(normalizedPath, root.PhysicalPath))
+                continue;
+
+            if (!ResolvedTargetIsTrusted(normalizedPath))
+                return LastSegmentOrUnknown(normalizedPath);
+
+            if (normalizedPath.Equals(root.PhysicalPath, StringComparison.OrdinalIgnoreCase))
+                return root.VirtualPath ?? LastSegmentOrUnknown(normalizedPath);
+
+            var relativePath = BuildCleanPath(normalizedPath[(root.PhysicalPath.Length + 1)..]);
+            return root.VirtualPath is null ? relativePath : $"{root.VirtualPath}/{relativePath}";
+        }
+
+        return null;
+    }
+
+    private bool ResolvedTargetIsTrusted(string normalizedPath)
+    {
+        var resolvedPath = TryResolvePath(_resolveFinalPath, normalizedPath);
+        return resolvedPath is null || IsUnderAnyVirtualRoot(resolvedPath);
+    }
+
+    private bool IsUnderAnyVirtualRoot(string normalizedPath) =>
+        _virtualRoots.Any(root =>
+            IsUnderRoot(normalizedPath, root.PhysicalPath) ||
+            root.ResolvedPhysicalPath is not null && IsUnderRoot(normalizedPath, root.ResolvedPhysicalPath));
+
+    private static bool IsUnderRoot(string path, string root) =>
+        path.Equals(root, StringComparison.OrdinalIgnoreCase) ||
+        path.StartsWith(root + '/', StringComparison.OrdinalIgnoreCase);
+
+    private static string? TryResolvePath(Func<string, string?> resolveFinalPath, string normalizedPath)
+    {
+        try
+        {
+            var resolvedPath = resolveFinalPath(normalizedPath);
+            return string.IsNullOrWhiteSpace(resolvedPath) ? null : NormalizePath(resolvedPath);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static string LastSegmentOrUnknown(string value)
+    {
+        var segments = GetPathSegments(value);
+        return segments.Length == 0 ? UnknownPath : segments[^1];
+    }
+
+    private static string BuildCleanPath(string value)
+    {
+        var segments = GetPathSegments(value);
+        return segments.Length == 0 ? LastSegmentOrUnknown(value) : string.Join('/', segments);
+    }
+
+    private static string? NormalizeVirtualPath(string? virtualPath)
+    {
+        if (string.IsNullOrWhiteSpace(virtualPath))
+            return null;
+
+        var normalized = BuildCleanPath(NormalizePath(virtualPath));
+        return normalized == UnknownPath ? null : normalized;
+    }
+
+    private static bool IsRootedPath(string path)
+    {
+        var value = path.Trim();
+        return Uri.TryCreate(value, UriKind.Absolute, out var uri) && uri.IsFile ||
+            Regex.IsMatch(value, @"^[A-Za-z]:[\\/]", RegexOptions.CultureInvariant) ||
+            value.StartsWith("\\\\", StringComparison.Ordinal) ||
+            value.StartsWith("/", StringComparison.Ordinal) ||
+            value.StartsWith("~/", StringComparison.Ordinal);
+    }
+
+    private static string? TryResolveFinalPath(string normalizedPath)
+    {
+        try
+        {
+            return ResolvePathAndAncestorLinks(Path.GetFullPath(ToNativePath(normalizedPath)));
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static string ResolvePathAndAncestorLinks(string fullPath)
+    {
+        var root = Path.GetPathRoot(fullPath);
+        if (string.IsNullOrWhiteSpace(root))
+            return fullPath;
+
+        var current = root.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        if (string.IsNullOrEmpty(current))
+            current = root;
+
+        foreach (var segment in Path.GetRelativePath(root, fullPath).Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar))
+        {
+            if (string.IsNullOrWhiteSpace(segment) || segment == ".")
+                continue;
+
+            current = Path.Combine(current, segment);
+            current = TryResolveSingleLink(current) ?? current;
+        }
+
+        return Path.GetFullPath(current);
+    }
+
+    private static string? TryResolveSingleLink(string path)
+    {
+        try
+        {
+            var target = Directory.Exists(path)
+                ? new DirectoryInfo(path).ResolveLinkTarget(returnFinalTarget: true)
+                : File.Exists(path)
+                    ? new FileInfo(path).ResolveLinkTarget(returnFinalTarget: true)
+                    : null;
+
+            if (target is null)
+                return null;
+
+            return Path.IsPathFullyQualified(target.FullName)
+                ? target.FullName
+                : Path.GetFullPath(target.FullName, Path.GetDirectoryName(path) ?? Directory.GetCurrentDirectory());
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static string ToNativePath(string normalizedPath) =>
+        normalizedPath.Replace('/', Path.DirectorySeparatorChar);
+
+    [GeneratedRegex(@"file:///[A-Za-z]:/[^\s""'<>]+", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex FileUriRegex();
+
+    [GeneratedRegex(@"\sin\s(?<path>[A-Za-z]:[\\/][^\r\n:]+):line\s", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex WindowsStackTracePathRegex();
+
+    [GeneratedRegex(@"(?<![A-Za-z0-9_])[A-Za-z]:[\\/][^\s""'<>]+", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex WindowsDrivePathRegex();
+
+    [GeneratedRegex(@"\\\\[^\\/\s""'<>]+[\\/][^\s""'<>]+", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex UncPathRegex();
+
+    [GeneratedRegex(@"(?<![A-Za-z0-9_])/(?:[^/\s""'<>:]+/)+[^/\s""'<>:]+", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex PosixPathRegex();
+
+    [GeneratedRegex(@"~/(?:[^/\s""'<>:]+/)*[^/\s""'<>:]+", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex HomePathRegex();
+
+    private sealed record NormalizedVirtualPathRoot(string PhysicalPath, string? VirtualPath, string? ResolvedPhysicalPath);
+
+    public sealed record VirtualPathRoot(string PhysicalPath, string? VirtualPath);
+}

--- a/src/KAST.Infrastructure/Services/ProcessManagerService.cs
+++ b/src/KAST.Infrastructure/Services/ProcessManagerService.cs
@@ -13,9 +13,8 @@ public class ProcessManagerService(ILogger<ProcessManagerService> logger) : IPro
     {
         using var activity = KastActivitySources.Process.StartActivity(
             "kast.process.start", ActivityKind.Internal);
-        activity?.SetTag("process.executable", executablePath);
 
-        logger.LogInformation("Starting process: {Executable} {Args}", executablePath, arguments);
+        logger.LogInformation("Starting server process");
 
         var psi = new ProcessStartInfo
         {
@@ -29,7 +28,7 @@ public class ProcessManagerService(ILogger<ProcessManagerService> logger) : IPro
         };
 
         var process = Process.Start(psi)
-            ?? throw new InvalidOperationException($"Failed to start process: {executablePath}");
+            ?? throw new InvalidOperationException("Failed to start server process.");
 
         logger.LogInformation("Process started with PID {Pid}", process.Id);
         activity?.SetTag("process.pid", process.Id);

--- a/src/KAST.Infrastructure/Services/ServerInstanceService.cs
+++ b/src/KAST.Infrastructure/Services/ServerInstanceService.cs
@@ -255,7 +255,7 @@ public class ServerInstanceService(
             var executable = GetServerExecutable(instance);
             var args = BuildLaunchArguments(instance);
 
-            activity?.SetTag("instance.executable", executable);
+            activity?.SetTag("instance.executable", sanitizer.ToDisplayPath(executable));
 
             logger.LogInformation("Starting server {Name}", instance.Name);
 

--- a/src/KAST.Infrastructure/Services/ServerInstanceService.cs
+++ b/src/KAST.Infrastructure/Services/ServerInstanceService.cs
@@ -155,7 +155,7 @@ public class ServerInstanceService(
             return;
 
         // 1) Per-instance config/profile directory: {InstallPath}/KAST/{id}
-        var configDir = Path.Combine(instance.InstallPath, "KAST", instance.Id.ToString());
+        var configDir = GetInstanceConfigDirectory(instance);
         TryDeleteDirectory(configDir, recursive: true);
 
         // 1b) On Linux, clean up the profile symlink we created in the system profiles dir.
@@ -164,7 +164,7 @@ public class ServerInstanceService(
 
         // 2) Mod symlinks created for this instance's mods (don't touch the mod
         //    source itself — that's shared and owned by ModService).
-        var modsDir = Path.Combine(instance.InstallPath, "mods");
+        var modsDir = GetInstanceModsDirectory(instance);
         if (Directory.Exists(modsDir))
         {
             foreach (var modLink in instance.Mods)
@@ -476,7 +476,7 @@ public class ServerInstanceService(
         activity?.SetTag("instance.name",        instance.Name);
         activity?.SetTag("instance.mods_total",  instance.Mods.Count);
 
-        var modsDir = Path.Combine(instance.InstallPath, "mods");
+        var modsDir = GetInstanceModsDirectory(instance);
         Directory.CreateDirectory(modsDir);
 
         int linkedCount = 0;
@@ -505,11 +505,19 @@ public class ServerInstanceService(
 
     private static string GetServerExecutable(ServerInstance instance)
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            return Path.Combine(instance.InstallPath, "arma3server_x64.exe");
+        var installPath = Path.GetFullPath(instance.InstallPath);
 
-        return Path.Combine(instance.InstallPath, "arma3server_x64");
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return Path.Combine(installPath, "arma3server_x64.exe");
+
+        return Path.Combine(installPath, "arma3server_x64");
     }
+
+    private static string GetInstanceConfigDirectory(ServerInstance instance)
+        => Path.GetFullPath(Path.Combine(instance.InstallPath, "KAST", instance.Id.ToString()));
+
+    private static string GetInstanceModsDirectory(ServerInstance instance)
+        => Path.GetFullPath(Path.Combine(instance.InstallPath, "mods"));
 
     public void WriteConfigFiles(ServerInstance instance)
     {
@@ -517,7 +525,7 @@ public class ServerInstanceService(
             Directory.CreateDirectory(instance.InstallPath);
 
         // Per-instance config directory
-        var configDir = Path.Combine(instance.InstallPath, "KAST", instance.Id.ToString());
+        var configDir = GetInstanceConfigDirectory(instance);
         Directory.CreateDirectory(configDir);
 
         if (instance.ServerCfgContent != null)
@@ -554,7 +562,7 @@ public class ServerInstanceService(
 
     private static string BuildLaunchArguments(ServerInstance instance)
     {
-        var configDir = Path.Combine(instance.InstallPath, "KAST");
+        var configDir = GetInstanceConfigDirectory(instance);
         var profileName = $"server_{instance.Id}";
 
         var args = new List<string>
@@ -638,7 +646,7 @@ public class ServerInstanceService(
         return instance.Mods
             .Where(m => m.IsClientSide)
             .OrderBy(m => m.LoadOrder)
-            .Select(m => Path.Combine(instance.InstallPath, "mods", $"@{SanitizeModName(m.SteamMod.Name)}"))
+            .Select(m => Path.Combine(GetInstanceModsDirectory(instance), $"@{SanitizeModName(m.SteamMod.Name)}"))
             .ToList();
     }
 
@@ -647,7 +655,7 @@ public class ServerInstanceService(
         var serverMods = instance.Mods
             .Where(m => m.IsServerSide)
             .OrderBy(m => m.LoadOrder)
-            .Select(m => Path.Combine(instance.InstallPath, "mods", $"@{SanitizeModName(m.SteamMod.Name)}"));
+            .Select(m => Path.Combine(GetInstanceModsDirectory(instance), $"@{SanitizeModName(m.SteamMod.Name)}"));
 
         return string.Join(";", serverMods);
     }

--- a/src/KAST.Infrastructure/Services/ServerInstanceService.cs
+++ b/src/KAST.Infrastructure/Services/ServerInstanceService.cs
@@ -7,6 +7,7 @@ using KAST.Core.Models;
 using KAST.Infrastructure.Data;
 using KAST.Infrastructure.Telemetry;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 namespace KAST.Infrastructure.Services;
@@ -15,7 +16,8 @@ public class ServerInstanceService(
     KastDbContext db,
     IProcessManagerService processManager,
     IAppEventBroadcaster broadcaster,
-    ILogger<ServerInstanceService> logger) : IServerInstanceService
+    ILogger<ServerInstanceService> logger,
+    IHostEnvironment? hostEnvironment = null) : IServerInstanceService
 {
     public async Task<IReadOnlyList<ServerInstance>> GetAllInstancesAsync(CancellationToken ct = default)
         => await db.ServerInstances
@@ -193,7 +195,7 @@ public class ServerInstanceService(
         // 3) Full install path — only when no other instance is using it.
         if (wipeInstallPath)
         {
-            TryDeleteDirectory(instance.InstallPath, recursive: true);
+            TryDeleteDirectory(GetInstanceInstallDirectory(instance), recursive: true);
             logger.LogInformation(
                 "Wiped install directory {Path} for instance {Id}",
                 instance.InstallPath, instance.Id);
@@ -503,9 +505,9 @@ public class ServerInstanceService(
         activity?.SetTag("instance.mods_linked", linkedCount);
     }
 
-    private static string GetServerExecutable(ServerInstance instance)
+    private string GetServerExecutable(ServerInstance instance)
     {
-        var installPath = Path.GetFullPath(instance.InstallPath);
+        var installPath = GetInstanceInstallDirectory(instance);
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             return Path.Combine(installPath, "arma3server_x64.exe");
@@ -513,16 +515,24 @@ public class ServerInstanceService(
         return Path.Combine(installPath, "arma3server_x64");
     }
 
-    private static string GetInstanceConfigDirectory(ServerInstance instance)
-        => Path.GetFullPath(Path.Combine(instance.InstallPath, "KAST", instance.Id.ToString()));
+    private string GetInstanceInstallDirectory(ServerInstance instance)
+    {
+        var installPath = Environment.ExpandEnvironmentVariables(instance.InstallPath);
+        return Path.IsPathFullyQualified(installPath)
+            ? Path.GetFullPath(installPath)
+            : Path.GetFullPath(installPath, hostEnvironment?.ContentRootPath ?? AppContext.BaseDirectory);
+    }
 
-    private static string GetInstanceModsDirectory(ServerInstance instance)
-        => Path.GetFullPath(Path.Combine(instance.InstallPath, "mods"));
+    private string GetInstanceConfigDirectory(ServerInstance instance)
+        => Path.Combine(GetInstanceInstallDirectory(instance), "KAST", instance.Id.ToString());
+
+    private string GetInstanceModsDirectory(ServerInstance instance)
+        => Path.Combine(GetInstanceInstallDirectory(instance), "mods");
 
     public void WriteConfigFiles(ServerInstance instance)
     {
         if (!string.IsNullOrEmpty(instance.InstallPath))
-            Directory.CreateDirectory(instance.InstallPath);
+            Directory.CreateDirectory(GetInstanceInstallDirectory(instance));
 
         // Per-instance config directory
         var configDir = GetInstanceConfigDirectory(instance);
@@ -560,7 +570,7 @@ public class ServerInstanceService(
         return $"{executable} {args}";
     }
 
-    private static string BuildLaunchArguments(ServerInstance instance)
+    private string BuildLaunchArguments(ServerInstance instance)
     {
         var configDir = GetInstanceConfigDirectory(instance);
         var profileName = $"server_{instance.Id}";
@@ -613,7 +623,7 @@ public class ServerInstanceService(
             args.Add($"-cpuCount={cfg.CpuCount}");
     }
 
-    private static void AddModArgs(ServerInstance instance, List<string> args)
+    private void AddModArgs(ServerInstance instance, List<string> args)
     {
         var dlcMods = GetDlcModsList(instance);
         var clientMods = GetClientModsList(instance);
@@ -641,7 +651,7 @@ public class ServerInstanceService(
         return dlcMods;
     }
 
-    private static List<string> GetClientModsList(ServerInstance instance)
+    private List<string> GetClientModsList(ServerInstance instance)
     {
         return instance.Mods
             .Where(m => m.IsClientSide)
@@ -650,7 +660,7 @@ public class ServerInstanceService(
             .ToList();
     }
 
-    private static string GetServerModsList(ServerInstance instance)
+    private string GetServerModsList(ServerInstance instance)
     {
         var serverMods = instance.Mods
             .Where(m => m.IsServerSide)

--- a/src/KAST.Infrastructure/Services/ServerInstanceService.cs
+++ b/src/KAST.Infrastructure/Services/ServerInstanceService.cs
@@ -17,6 +17,7 @@ public class ServerInstanceService(
     IProcessManagerService processManager,
     IAppEventBroadcaster broadcaster,
     ILogger<ServerInstanceService> logger,
+    IOutputSanitizer sanitizer,
     IHostEnvironment? hostEnvironment = null) : IServerInstanceService
 {
     public async Task<IReadOnlyList<ServerInstance>> GetAllInstancesAsync(CancellationToken ct = default)
@@ -120,9 +121,6 @@ public class ServerInstanceService(
             && await db.ServerInstances
                 .AnyAsync(s => s.Id != id && s.InstallPath == installPath, ct);
 
-        activity?.SetTag("instance.install_path", installPath ?? "");
-        activity?.SetTag("instance.path_shared",  isInstallPathShared);
-
         db.ServerInstances.Remove(instance);
         await db.SaveChangesAsync(ct);
 
@@ -134,15 +132,15 @@ public class ServerInstanceService(
         }
         catch (Exception ex)
         {
-            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            activity?.SetStatus(ActivityStatusCode.Error, sanitizer.Sanitize(ex.Message));
             activity?.AddEvent(new ActivityEvent("exception", tags: new ActivityTagsCollection
             {
                 ["exception.type"]    = ex.GetType().Name,
-                ["exception.message"] = ex.Message
+                ["exception.message"] = sanitizer.Sanitize(ex.Message)
             }));
             logger.LogError(ex,
-                "Failed to clean up files for deleted instance {Id} ({Name}) at {Path}",
-                id, instance.Name, installPath);
+                "Failed to clean up files for deleted instance {Id} ({Name})",
+                id, instance.Name);
         }
     }
 
@@ -187,7 +185,7 @@ public class ServerInstanceService(
                 }
                 catch (Exception ex)
                 {
-                    logger.LogWarning(ex, "Failed to remove mod symlink {Path}", linkPath);
+                    logger.LogWarning(ex, "Failed to remove mod symlink for instance {Id}", instance.Id);
                 }
             }
         }
@@ -197,14 +195,14 @@ public class ServerInstanceService(
         {
             TryDeleteDirectory(GetInstanceInstallDirectory(instance), recursive: true);
             logger.LogInformation(
-                "Wiped install directory {Path} for instance {Id}",
-                instance.InstallPath, instance.Id);
+                "Wiped install directory for instance {Id}",
+                instance.Id);
         }
         else
         {
             logger.LogInformation(
-                "Kept install directory {Path} (shared with other instances) for instance {Id}",
-                instance.InstallPath, instance.Id);
+                "Kept install directory shared with other instances for instance {Id}",
+                instance.Id);
         }
     }
 
@@ -219,7 +217,7 @@ public class ServerInstanceService(
         }
         catch (Exception ex)
         {
-            logger.LogWarning(ex, "Failed to delete directory {Path}", path);
+            logger.LogWarning(ex, "Failed to delete instance directory");
         }
     }
 
@@ -259,7 +257,7 @@ public class ServerInstanceService(
 
             activity?.SetTag("instance.executable", executable);
 
-            logger.LogInformation("Starting server {Name} with args: {Args}", instance.Name, args);
+            logger.LogInformation("Starting server {Name}", instance.Name);
 
             // Callbacks for stdout/stderr lines and process exit
             void OnOutputLine(int pid, string line)
@@ -314,11 +312,11 @@ public class ServerInstanceService(
         catch (Exception ex)
         {
             logger.LogError(ex, "Failed to start server instance {Id}", id);
-            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            activity?.SetStatus(ActivityStatusCode.Error, sanitizer.Sanitize(ex.Message));
             activity?.AddEvent(new ActivityEvent("exception", tags: new ActivityTagsCollection
             {
                 ["exception.type"]    = ex.GetType().Name,
-                ["exception.message"] = ex.Message
+                ["exception.message"] = sanitizer.Sanitize(ex.Message)
             }));
             // If the process never got a PID the server never actually ran — reset to Stopped
             // so the user can try again. Crashed is reserved for processes that ran and then died.
@@ -396,11 +394,11 @@ public class ServerInstanceService(
         }
         catch (Exception ex)
         {
-            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            activity?.SetStatus(ActivityStatusCode.Error, sanitizer.Sanitize(ex.Message));
             activity?.AddEvent(new ActivityEvent("exception", tags: new ActivityTagsCollection
             {
                 ["exception.type"]    = ex.GetType().Name,
-                ["exception.message"] = ex.Message
+                ["exception.message"] = sanitizer.Sanitize(ex.Message)
             }));
             throw;
         }
@@ -498,7 +496,7 @@ public class ServerInstanceService(
             }
 
             Directory.CreateSymbolicLink(linkPath, mod.LocalPath);
-            logger.LogInformation("Linked mod {ModName} -> {LinkPath}", mod.Name, linkPath);
+            logger.LogInformation("Linked mod {ModName}", mod.Name);
             linkedCount++;
         }
 
@@ -739,7 +737,7 @@ public class ServerInstanceService(
             if (File.Exists(symlinkPath) || Directory.Exists(symlinkPath))
             {
                 File.Delete(symlinkPath);
-                logger.LogInformation("Removed Linux profile symlink {Path}", symlinkPath);
+                logger.LogInformation("Removed Linux profile symlink");
             }
         }
         catch (Exception ex)

--- a/src/KAST.Infrastructure/Steam/CdnServerPool.cs
+++ b/src/KAST.Infrastructure/Steam/CdnServerPool.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using KAST.Core.Interfaces;
 using KAST.Infrastructure.Telemetry;
 using Microsoft.Extensions.Logging;
 using SteamKit2;
@@ -29,6 +30,7 @@ internal sealed class CdnServerPool : IDisposable
     private readonly SteamClient _steamClient;
     private readonly SteamContent _steamContent;
     private readonly ILogger _logger;
+    private readonly IOutputSanitizer _sanitizer;
     private readonly CancellationTokenSource _cts;
 
     // Proven-good servers from the current session — consumed first (LIFO)
@@ -52,11 +54,13 @@ internal sealed class CdnServerPool : IDisposable
         SteamClient steamClient,
         SteamContent steamContent,
         ILogger logger,
+        IOutputSanitizer sanitizer,
         CancellationToken parentCt = default)
     {
         _steamClient = steamClient;
         _steamContent = steamContent;
         _logger = logger;
+        _sanitizer = sanitizer;
         _cts = CancellationTokenSource.CreateLinkedTokenSource(parentCt);
         _monitorTask = Task.Run(MonitorAsync);
     }
@@ -178,11 +182,12 @@ internal sealed class CdnServerPool : IDisposable
                 }
                 catch (Exception refillEx) when (refillEx is not OperationCanceledException)
                 {
-                    refillActivity?.SetStatus(ActivityStatusCode.Error, refillEx.Message);
+                    var safeMessage = _sanitizer.Sanitize(refillEx.Message);
+                    refillActivity?.SetStatus(ActivityStatusCode.Error, safeMessage);
                     refillActivity?.AddEvent(new ActivityEvent("exception", tags: new ActivityTagsCollection
                     {
                         ["exception.type"]    = refillEx.GetType().Name,
-                        ["exception.message"] = refillEx.Message
+                        ["exception.message"] = safeMessage
                     }));
                     throw;
                 }

--- a/src/KAST.Infrastructure/Steam/SteamClientService.cs
+++ b/src/KAST.Infrastructure/Steam/SteamClientService.cs
@@ -14,6 +14,7 @@ namespace KAST.Infrastructure.Steam;
 public class SteamClientService : ISteamService, IDisposable
 {
     private readonly ILogger<SteamClientService> _logger;
+    private readonly IOutputSanitizer _sanitizer;
     private readonly SteamClient _steamClient;
     private readonly CallbackManager _callbackManager;
     private readonly SteamUser _steamUser;
@@ -126,9 +127,10 @@ public class SteamClientService : ISteamService, IDisposable
     public SteamUserProfile? Profile => _profile;
     public event Action? AuthStateChanged;
 
-    public SteamClientService(ILogger<SteamClientService> logger)
+    public SteamClientService(ILogger<SteamClientService> logger, IOutputSanitizer sanitizer)
     {
         _logger = logger;
+        _sanitizer = sanitizer;
         _steamClient = new SteamClient();
         _callbackManager = new CallbackManager(_steamClient);
         _steamUser = _steamClient.GetHandler<SteamUser>()!;
@@ -367,10 +369,11 @@ public class SteamClientService : ISteamService, IDisposable
         }
         catch (Exception ex)
         {
-            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            var safeMessage = _sanitizer.Sanitize(ex.Message);
+            activity?.SetStatus(ActivityStatusCode.Error, safeMessage);
             RecordExceptionEvent(activity, ex);
             _logger.LogError(ex, "Failed to begin QR auth session");
-            return new SteamQrAuthSession { ErrorMessage = ex.Message };
+            return new SteamQrAuthSession { ErrorMessage = safeMessage };
         }
         finally
         {
@@ -426,10 +429,11 @@ public class SteamClientService : ISteamService, IDisposable
         }
         catch (Exception ex)
         {
-            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            var safeMessage = _sanitizer.Sanitize(ex.Message);
+            activity?.SetStatus(ActivityStatusCode.Error, safeMessage);
             RecordExceptionEvent(activity, ex);
             _logger.LogError(ex, "Failed to begin credential auth session for {Username}", username);
-            return new SteamCredentialAuthSession { ErrorMessage = ex.Message };
+            return new SteamCredentialAuthSession { ErrorMessage = safeMessage };
         }
         finally
         {
@@ -496,12 +500,13 @@ public class SteamClientService : ISteamService, IDisposable
         }
         catch (Exception ex)
         {
-            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            var safeMessage = _sanitizer.Sanitize(ex.Message);
+            activity?.SetStatus(ActivityStatusCode.Error, safeMessage);
             RecordExceptionEvent(activity, ex);
             _logger.LogWarning(ex, "Credential auth polling failed");
             _activeCredentialSession = null;
             _activeCredentialAuthenticator = null;
-            session.ErrorMessage = ex.Message;
+            session.ErrorMessage = safeMessage;
             session.StateChanged?.Invoke();
             return false;
         }
@@ -551,7 +556,7 @@ public class SteamClientService : ISteamService, IDisposable
         }
         catch (Exception ex)
         {
-            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            activity?.SetStatus(ActivityStatusCode.Error, _sanitizer.Sanitize(ex.Message));
             RecordExceptionEvent(activity, ex);
             _logger.LogWarning(ex, "QR auth polling failed");
             _activeQrSession = null;
@@ -568,9 +573,9 @@ public class SteamClientService : ISteamService, IDisposable
         if (!_isConnected)
             throw new InvalidOperationException("Not connected to Steam");
 
-        using var activity = KastActivitySources.Steam.StartActivity(
+        using var activity = KastActivitySources.Content.StartActivity(
             "kast.steam.unified.workshop_details", ActivityKind.Client);
-        activity?.SetTag("workshop.id", workshopId);
+        activity?.SetTag("workshop.id",          workshopId);
 
         try
         {
@@ -620,7 +625,7 @@ public class SteamClientService : ISteamService, IDisposable
         }
         catch (Exception ex)
         {
-            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            activity?.SetStatus(ActivityStatusCode.Error, _sanitizer.Sanitize(ex.Message));
             RecordExceptionEvent(activity, ex);
             throw;
         }
@@ -637,8 +642,7 @@ public class SteamClientService : ISteamService, IDisposable
     // Arma 3 AppID — used as both appId and depotId for workshop items (same as FASTER & BytexDigital)
     private const uint Arma3AppId = 107410;
 
-    public async Task<ulong> DownloadWorkshopItemAsync(
-        long workshopId, string destinationPath,
+    public async Task<ulong> DownloadWorkshopItemAsync(long workshopId, string destinationPath,
         IProgress<double>? progress = null, CancellationToken ct = default)
     {
         if (!_isConnected)
@@ -649,7 +653,6 @@ public class SteamClientService : ISteamService, IDisposable
         using var workshopActivity = KastActivitySources.Content.StartActivity(
             "kast.steam.workshop_download", ActivityKind.Internal);
         workshopActivity?.SetTag("workshop.id",          workshopId);
-        workshopActivity?.SetTag("workshop.destination", destinationPath);
 
         try
         {
@@ -723,14 +726,14 @@ public class SteamClientService : ISteamService, IDisposable
         workshopActivity?.SetTag("workshop.duration_s",     Math.Round(dlElapsed.TotalSeconds, 1));
         workshopActivity?.SetTag("workshop.avg_mbps",       Math.Round(avgMbps, 2));
 
-        _logger.LogInformation("Workshop item {Id} download complete → {Path}  ({Mb:F1} MB in {Sec:F1}s, {Mbps:F1} MB/s avg)",
-            workshopId, destinationPath, totalMbDownloaded, dlElapsed.TotalSeconds, avgMbps);
+        _logger.LogInformation("Workshop item {Id} download complete ({Mb:F1} MB in {Sec:F1}s, {Mbps:F1} MB/s avg)",
+            workshopId, totalMbDownloaded, dlElapsed.TotalSeconds, avgMbps);
         progress?.Report(100);
         return manifestId;
         }
         catch (Exception ex)
         {
-            workshopActivity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            workshopActivity?.SetStatus(ActivityStatusCode.Error, _sanitizer.Sanitize(ex.Message));
             RecordExceptionEvent(workshopActivity, ex);
             throw;
         }
@@ -981,7 +984,7 @@ public class SteamClientService : ISteamService, IDisposable
         }
         catch (Exception ex)
         {
-            depotActivity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            depotActivity?.SetStatus(ActivityStatusCode.Error, _sanitizer.Sanitize(ex.Message));
             RecordExceptionEvent(depotActivity, ex);
             throw;
         }
@@ -997,14 +1000,13 @@ public class SteamClientService : ISteamService, IDisposable
 
     /// Records an exception as a span event using the OTel semantic convention,
     /// equivalent to Activity.RecordException() from the OpenTelemetry SDK.
-    private static void RecordExceptionEvent(Activity? activity, Exception ex)
+    private void RecordExceptionEvent(Activity? activity, Exception ex)
     {
         if (activity is null) return;
         activity.AddEvent(new ActivityEvent("exception", tags: new ActivityTagsCollection
         {
-            ["exception.type"]       = ex.GetType().FullName ?? ex.GetType().Name,
-            ["exception.message"]    = ex.Message,
-            ["exception.stacktrace"] = ex.StackTrace ?? string.Empty
+            ["exception.type"]    = ex.GetType().FullName ?? ex.GetType().Name,
+            ["exception.message"] = _sanitizer.Sanitize(ex.Message)
         }));
     }
 
@@ -1053,7 +1055,7 @@ public class SteamClientService : ISteamService, IDisposable
             spanActivity?.AddEvent(new ActivityEvent("manifest.server_fallback", tags: new ActivityTagsCollection
             {
                 ["cdn.server"]        = server.Host,
-                ["exception.message"] = ex.Message
+                ["exception.message"] = _sanitizer.Sanitize(ex.Message)
             }));
             pool.ReturnServer(server, true); // discard faulty server
             server = pool.GetServer(ct);     // get a fresh one
@@ -1127,9 +1129,9 @@ public class SteamClientService : ISteamService, IDisposable
                     "kast.steam.file_download",
                     ActivityKind.Internal,
                     parentSpanContext);
-                fileActivity?.SetTag("file.name",        relativePath);
                 fileActivity?.SetTag("file.size_mb",     Math.Round(fileSizeMb, 2));
                 fileActivity?.SetTag("file.chunk_count", file.Chunks.Count);
+                fileActivity?.SetTag("file.relative_path", _sanitizer.ToDisplayPath(relativePath));
                 fileActivity?.SetTag("depot.id",         depotId);
 
                 try
@@ -1137,7 +1139,8 @@ public class SteamClientService : ISteamService, IDisposable
                     var dir = Path.GetDirectoryName(filePath);
                     if (dir != null) Directory.CreateDirectory(dir);
 
-                    _logger.LogDebug("{Prefix}: downloading {File} ({Size:F2} MB)", logPrefix, relativePath, fileSizeMb);
+                    _logger.LogDebug("{Prefix}: downloading file {Path} ({Size:F2} MB)",
+                        logPrefix, _sanitizer.ToDisplayPath(relativePath), fileSizeMb);
 
                     await using var fs = File.Create(filePath);
                     if (file.TotalSize > 0)
@@ -1157,7 +1160,8 @@ public class SteamClientService : ISteamService, IDisposable
                     }
 
                     var done = Interlocked.Increment(ref filesDone);
-                    _logger.LogDebug("{Prefix}: [{Done}/{Total}] {File}", logPrefix, done, files.Count, relativePath);
+                    _logger.LogDebug("{Prefix}: [{Done}/{Total}] file downloaded: {Path}",
+                        logPrefix, done, files.Count, _sanitizer.ToDisplayPath(relativePath));
 
                     // Speed + progress report: every 10 files, large files (≥ 50 MB), last file, or every 5 s
                     var nowBytes       = Interlocked.Read(ref bytesDownloaded);
@@ -1170,7 +1174,7 @@ public class SteamClientService : ISteamService, IDisposable
                         var mbps        = secSinceReport > 0 ? (deltaBytes / 1_048_576.0) / secSinceReport : 0;
                         var totalMbDone = nowBytes / 1_048_576.0;
 
-                        var report = $"  [{done}/{files.Count}] {relativePath}  —  {totalMbDone:F0}/{downloadMb:F0} MB  ({mbps:F1} MB/s)";
+                        var report = $"  [{done}/{files.Count}] {_sanitizer.ToDisplayPath(relativePath)}  —  {totalMbDone:F0}/{downloadMb:F0} MB  ({mbps:F1} MB/s)";
                         logProgress?.Report(report);
                         // When no logProgress channel exists (e.g. workshop download), surface via logger.
                         if (logProgress is null)
@@ -1191,7 +1195,7 @@ public class SteamClientService : ISteamService, IDisposable
                 }
                 catch (Exception ex)
                 {
-                    fileActivity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+                    fileActivity?.SetStatus(ActivityStatusCode.Error, _sanitizer.Sanitize(ex.Message));
                     RecordExceptionEvent(fileActivity, ex);
                     throw;
                 }
@@ -1236,9 +1240,8 @@ public class SteamClientService : ISteamService, IDisposable
                     ["chunk.id"]      = chunk.ChunkID is { Length: > 0 } ? Convert.ToHexString(chunk.ChunkID) : "unknown",
                     ["chunk.attempt"] = attempt + 1,
                     ["cdn.server"]    = server.Host,
-                    ["error"]         = ex.Message
+                    ["error"]         = _sanitizer.Sanitize(ex.Message)
                 }));
-
                 pool.ReturnServer(server, true); // faulty — permanently discard it
 
                 if (attempt < MaxChunkRetries - 1)
@@ -1266,12 +1269,11 @@ public class SteamClientService : ISteamService, IDisposable
             "kast.steam.app_download", ActivityKind.Internal);
         appActivity?.SetTag("app.id",              appId);
         appActivity?.SetTag("app.branch",          branch);
-        appActivity?.SetTag("app.destination",     destinationPath);
         appActivity?.SetTag("app.parallel_workers", maxParallelDownloads);
 
         try
         {
-        _logger.LogInformation("Starting app download for AppId {AppId} → {Path}", appId, destinationPath);
+        _logger.LogInformation("Starting app download for AppId {AppId}", appId);
         logProgress?.Report($"Starting download for AppId {appId}...");
         progress?.Report(0);
 
@@ -1400,7 +1402,7 @@ public class SteamClientService : ISteamService, IDisposable
             ? $"Already up-to-date — {skippedDepots} depot(s) unchanged, {grandVerified} file(s) verified."
             : $"Complete — {grandVerified} file(s) already up-to-date, {grandDownloaded} file(s) updated, {skippedDepots} depot(s) skipped.";
 
-        _logger.LogInformation("App {AppId} complete → {Path}", appId, destinationPath);
+        _logger.LogInformation("App {AppId} complete", appId);
         logProgress?.Report(summary);
         progress?.Report(100);
 
@@ -1410,7 +1412,7 @@ public class SteamClientService : ISteamService, IDisposable
         }
         catch (Exception ex)
         {
-            appActivity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            appActivity?.SetStatus(ActivityStatusCode.Error, _sanitizer.Sanitize(ex.Message));
             RecordExceptionEvent(appActivity, ex);
             throw;
         }
@@ -1463,7 +1465,7 @@ public class SteamClientService : ISteamService, IDisposable
         if (_cdnPool is not null)
             return Task.FromResult(_cdnPool);
 
-        _cdnPool = new CdnServerPool(_steamClient, _steamContent, _logger);
+        _cdnPool = new CdnServerPool(_steamClient, _steamContent, _logger, _sanitizer);
         _logger.LogInformation("CDN server pool created");
         return Task.FromResult(_cdnPool);
     }
@@ -1610,7 +1612,7 @@ public class SteamClientService : ISteamService, IDisposable
         }
         catch (Exception ex)
         {
-            benchActivity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            benchActivity?.SetStatus(ActivityStatusCode.Error, _sanitizer.Sanitize(ex.Message));
             RecordExceptionEvent(benchActivity, ex);
             throw;
         }

--- a/src/KAST.Infrastructure/Steam/SteamWebApiClient.cs
+++ b/src/KAST.Infrastructure/Steam/SteamWebApiClient.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Logging;
 
 namespace KAST.Infrastructure.Steam;
 
-public class SteamWebApiClient(HttpClient httpClient, ILogger<SteamWebApiClient> logger)
+public class SteamWebApiClient(HttpClient httpClient, ILogger<SteamWebApiClient> logger, IOutputSanitizer sanitizer)
 {
     private const string BaseUrl = "https://api.steampowered.com";
 
@@ -71,11 +71,12 @@ public class SteamWebApiClient(HttpClient httpClient, ILogger<SteamWebApiClient>
         }
         catch (Exception ex)
         {
-            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            var safeMessage = sanitizer.Sanitize(ex.Message);
+            activity?.SetStatus(ActivityStatusCode.Error, safeMessage);
             activity?.AddEvent(new ActivityEvent("exception", tags: new ActivityTagsCollection
             {
                 ["exception.type"]    = ex.GetType().Name,
-                ["exception.message"] = ex.Message
+                ["exception.message"] = safeMessage
             }));
             throw;
         }
@@ -103,7 +104,7 @@ public class SteamWebApiClient(HttpClient httpClient, ILogger<SteamWebApiClient>
         catch (Exception ex)
         {
             logger.LogWarning(ex, "Failed to discover CDN servers via Web API");
-            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            activity?.SetStatus(ActivityStatusCode.Error, sanitizer.Sanitize(ex.Message));
             return null;
         }
     }

--- a/src/KAST.UI/Api/KastApiEndpoints.cs
+++ b/src/KAST.UI/Api/KastApiEndpoints.cs
@@ -29,25 +29,25 @@ public static class KastApiEndpoints
     {
         var g = root.MapGroup("/servers").WithTags("Servers");
 
-        g.MapGet("/", async (IServerInstanceService svc, CancellationToken ct) =>
-            Results.Ok(await svc.GetAllInstancesAsync(ct)));
+        g.MapGet("/", async (IServerInstanceService svc, [FromServices] IOutputSanitizer sanitizer, CancellationToken ct) =>
+            Results.Ok((await svc.GetAllInstancesAsync(ct)).Select(instance => ToServerDto(instance, sanitizer))));
 
-        g.MapGet("/{id:int}", async (int id, IServerInstanceService svc, CancellationToken ct) =>
+        g.MapGet("/{id:int}", async (int id, IServerInstanceService svc, [FromServices] IOutputSanitizer sanitizer, CancellationToken ct) =>
         {
             var inst = await svc.GetInstanceByIdAsync(id, ct);
-            return inst is null ? Results.NotFound() : Results.Ok(inst);
+            return inst is null ? Results.NotFound() : Results.Ok(ToServerDto(inst, sanitizer));
         });
 
-        g.MapPost("/", async (ServerInstance instance, IServerInstanceService svc, CancellationToken ct) =>
+        g.MapPost("/", async (ServerInstance instance, IServerInstanceService svc, [FromServices] IOutputSanitizer sanitizer, CancellationToken ct) =>
         {
             var created = await svc.CreateInstanceAsync(instance, ct);
-            return Results.Created($"/api/servers/{created.Id}", created);
+            return Results.Created($"/api/servers/{created.Id}", ToServerDto(created, sanitizer));
         });
 
-        g.MapPut("/{id:int}", async (int id, ServerInstance instance, IServerInstanceService svc, CancellationToken ct) =>
+        g.MapPut("/{id:int}", async (int id, ServerInstance instance, IServerInstanceService svc, [FromServices] IOutputSanitizer sanitizer, CancellationToken ct) =>
         {
             instance.Id = id;
-            return Results.Ok(await svc.UpdateInstanceAsync(instance, ct));
+            return Results.Ok(ToServerDto(await svc.UpdateInstanceAsync(instance, ct), sanitizer));
         });
 
         g.MapDelete("/{id:int}", async (int id, IServerInstanceService svc, CancellationToken ct) =>
@@ -93,25 +93,25 @@ public static class KastApiEndpoints
     {
         var g = root.MapGroup("/mods").WithTags("Mods");
 
-        g.MapGet("/", async (IModService svc, CancellationToken ct) =>
-            Results.Ok(await svc.GetAllModsAsync(ct)));
+        g.MapGet("/", async (IModService svc, [FromServices] IOutputSanitizer sanitizer, CancellationToken ct) =>
+            Results.Ok((await svc.GetAllModsAsync(ct)).Select(mod => ToModDto(mod, sanitizer))));
 
-        g.MapGet("/{id:int}", async (int id, IModService svc, CancellationToken ct) =>
+        g.MapGet("/{id:int}", async (int id, IModService svc, [FromServices] IOutputSanitizer sanitizer, CancellationToken ct) =>
         {
             var mod = await svc.GetModByIdAsync(id, ct);
-            return mod is null ? Results.NotFound() : Results.Ok(mod);
+            return mod is null ? Results.NotFound() : Results.Ok(ToModDto(mod, sanitizer));
         });
 
-        g.MapPost("/workshop/{workshopId:long}", async (long workshopId, IModService svc, CancellationToken ct) =>
+        g.MapPost("/workshop/{workshopId:long}", async (long workshopId, IModService svc, [FromServices] IOutputSanitizer sanitizer, CancellationToken ct) =>
         {
             var mod = await svc.AddWorkshopModAsync(workshopId, ct);
-            return Results.Created($"/api/mods/{mod.Id}", mod);
+            return Results.Created($"/api/mods/{mod.Id}", ToModDto(mod, sanitizer));
         });
 
-        g.MapPost("/local", async (ImportLocalModRequest req, IModService svc, CancellationToken ct) =>
+        g.MapPost("/local", async (ImportLocalModRequest req, IModService svc, [FromServices] IOutputSanitizer sanitizer, CancellationToken ct) =>
         {
             var mod = await svc.ImportLocalModAsync(req.Path, req.Name, ct);
-            return Results.Created($"/api/mods/{mod.Id}", mod);
+            return Results.Created($"/api/mods/{mod.Id}", ToModDto(mod, sanitizer));
         });
 
         g.MapDelete("/{id:int}", async (int id, IModService svc, CancellationToken ct) =>
@@ -250,8 +250,8 @@ public static class KastApiEndpoints
     {
         var g = root.MapGroup("/settings").WithTags("Settings");
 
-        g.MapGet("/", async (ISettingsService svc, CancellationToken ct) =>
-            Results.Ok(await svc.GetSettingsAsync(ct)));
+        g.MapGet("/", async (ISettingsService svc, [FromServices] IOutputSanitizer sanitizer, CancellationToken ct) =>
+            Results.Ok(ToSettingsDto(await svc.GetSettingsAsync(ct), sanitizer)));
 
         g.MapPut("/", async (KastSettings settings, ISettingsService svc, CancellationToken ct) =>
         {
@@ -274,7 +274,169 @@ public static class KastApiEndpoints
             return Results.NoContent();
         });
     }
-}
 
-public record ImportLocalModRequest(string Path, string Name);
-public record CreateApiKeyRequest(string Name);
+    private static SafeServerInstanceDto ToServerDto(ServerInstance instance, IOutputSanitizer sanitizer) => new(
+        instance.Id,
+        instance.Name,
+        sanitizer.ToDisplayPath(instance.InstallPath),
+        instance.Port,
+        instance.SteamQueryPort,
+        instance.Status,
+        instance.RestartPolicy,
+        instance.MaxRestartAttempts,
+        instance.AutoStartTime,
+        instance.AutoStopTime,
+        instance.ScheduleEnabled,
+        instance.ServerCfgContent,
+        instance.BasicCfgContent,
+        instance.ArmaProfileContent,
+        instance.AdditionalParameters,
+        instance.ContactDlc,
+        instance.GmDlc,
+        instance.PfDlc,
+        instance.CslaDlc,
+        instance.WsDlc,
+        instance.SpeDlc,
+        instance.RfDlc,
+        instance.EfDlc,
+        instance.InstalledAt,
+        instance.InstalledBuildId,
+        instance.ProcessId,
+        instance.StartedAt,
+        instance.HeadlessClientCount,
+        instance.CreatedAt,
+        instance.LastModified,
+        instance.Mods.Select(mod => ToServerModDto(mod, sanitizer)).ToList(),
+        instance.HeadlessClients.Select(ToHeadlessClientDto).ToList());
+
+    private static SafeServerInstanceModDto ToServerModDto(ServerInstanceMod mod, IOutputSanitizer sanitizer) => new(
+        mod.ServerInstanceId,
+        mod.SteamModId,
+        mod.IsClientSide,
+        mod.IsServerSide,
+        mod.LoadOrder,
+        mod.AddedAt,
+        ToModDto(mod.SteamMod, sanitizer));
+
+    private static SafeHeadlessClientDto ToHeadlessClientDto(HeadlessClient client) => new(
+        client.Id,
+        client.ServerInstanceId,
+        client.ProcessId,
+        client.Status,
+        client.StartedAt);
+
+    private static SafeSteamModDto ToModDto(SteamMod mod, IOutputSanitizer sanitizer) => new(
+        mod.Id,
+        mod.WorkshopId,
+        sanitizer.ToDisplayPath(mod.LocalPath),
+        mod.Name,
+        mod.Description,
+        mod.ThumbnailUrl,
+        mod.Author,
+        mod.SizeBytes,
+        mod.ExpectedSizeBytes,
+        mod.Source,
+        mod.Status,
+        mod.LastUpdatedSteam,
+        mod.LastUpdatedLocal,
+        mod.LastChecked,
+        mod.Comment,
+        mod.CreatedAt,
+        mod.InstalledManifestId,
+        mod.SteamManifestId,
+        mod.IsClientSide,
+        mod.IsServerSide);
+
+    private static SafeKastSettingsDto ToSettingsDto(KastSettings settings, IOutputSanitizer sanitizer) => new(
+        settings.Id,
+        settings.Arma3ServerAppId,
+        sanitizer.ToDisplayPath(settings.ModsDirectory),
+        sanitizer.ToDisplayPath(settings.ServersDirectory),
+        settings.ThemeMode,
+        settings.MetricsIntervalSeconds,
+        settings.ParallelDownloads);
+
+    public record SafeServerInstanceDto(
+        int Id,
+        string Name,
+        string InstallPath,
+        int Port,
+        int SteamQueryPort,
+        ServerInstanceStatus Status,
+        RestartPolicy RestartPolicy,
+        int MaxRestartAttempts,
+        string? AutoStartTime,
+        string? AutoStopTime,
+        bool ScheduleEnabled,
+        string? ServerCfgContent,
+        string? BasicCfgContent,
+        string? ArmaProfileContent,
+        string? AdditionalParameters,
+        bool ContactDlc,
+        bool GmDlc,
+        bool PfDlc,
+        bool CslaDlc,
+        bool WsDlc,
+        bool SpeDlc,
+        bool RfDlc,
+        bool EfDlc,
+        DateTime? InstalledAt,
+        string? InstalledBuildId,
+        int? ProcessId,
+        DateTime? StartedAt,
+        int HeadlessClientCount,
+        DateTime CreatedAt,
+        DateTime? LastModified,
+        IReadOnlyList<SafeServerInstanceModDto> Mods,
+        IReadOnlyList<SafeHeadlessClientDto> HeadlessClients);
+
+    public record SafeServerInstanceModDto(
+        int ServerInstanceId,
+        int SteamModId,
+        bool IsClientSide,
+        bool IsServerSide,
+        int LoadOrder,
+        DateTime AddedAt,
+        SafeSteamModDto SteamMod);
+
+    public record SafeHeadlessClientDto(
+        int Id,
+        int ServerInstanceId,
+        int? ProcessId,
+        ServerInstanceStatus Status,
+        DateTime? StartedAt);
+
+    public record SafeSteamModDto(
+        int Id,
+        long WorkshopId,
+        string LocalPath,
+        string Name,
+        string? Description,
+        string? ThumbnailUrl,
+        string? Author,
+        long SizeBytes,
+        long ExpectedSizeBytes,
+        ModSource Source,
+        ModStatus Status,
+        DateTime? LastUpdatedSteam,
+        DateTime? LastUpdatedLocal,
+        DateTime? LastChecked,
+        string? Comment,
+        DateTime CreatedAt,
+        ulong InstalledManifestId,
+        ulong SteamManifestId,
+        bool IsClientSide,
+        bool IsServerSide);
+
+    public record SafeKastSettingsDto(
+        int Id,
+        int Arma3ServerAppId,
+        string ModsDirectory,
+        string ServersDirectory,
+        string ThemeMode,
+        int MetricsIntervalSeconds,
+        int ParallelDownloads);
+
+    public record ImportLocalModRequest(string Path, string Name);
+    public record CreateApiKeyRequest(string Name);
+}

--- a/src/KAST.UI/Components/Pages/Mods.razor
+++ b/src/KAST.UI/Components/Pages/Mods.razor
@@ -5,6 +5,7 @@
 @using Microsoft.AspNetCore.Components.Forms
 @inject IModService ModService
 @inject IAppEventBroadcaster Broadcaster
+@inject IOutputSanitizer OutputSanitizer
 @inject ISnackbar Snackbar
 @implements IAsyncDisposable
 
@@ -475,8 +476,8 @@ else
                             @if (!string.IsNullOrWhiteSpace(_selectedMod.LocalPath))
                             {
                                 <tr>
-                                    <td style="opacity:.7;vertical-align:top;">Path</td>
-                                    <td><code style="font-size:11px; word-break:break-all;">@_selectedMod.LocalPath</code></td>
+                                    <td style="opacity:.7;">Files</td>
+                                    <td><code style="font-size:11px;">@OutputSanitizer.ToDisplayPath(_selectedMod.LocalPath)</code></td>
                                 </tr>
                             }
                         </tbody>
@@ -801,7 +802,7 @@ else
         }
         catch (Exception ex)
         {
-            Snackbar.Add($"Failed to parse preset file: {ex.Message}", Severity.Error);
+            Snackbar.Add($"Failed to parse preset file: {OutputSanitizer.SanitizeException(ex)}", Severity.Error);
         }
     }
 
@@ -873,17 +874,21 @@ else
             await RefreshMods();
             Snackbar.Add("Mod added successfully", Severity.Success);
         }
-        catch (Exception ex) { Snackbar.Add($"Failed: {ex.Message}", Severity.Error); }
+        catch (Exception ex) { Snackbar.Add($"Failed: {OutputSanitizer.SanitizeException(ex)}", Severity.Error); }
     }
 
     private async Task ImportLocalMod()
     {
         if (string.IsNullOrWhiteSpace(_localModName) || string.IsNullOrWhiteSpace(_localModPath)) return;
-        await ModService.ImportLocalModAsync(_localModPath, _localModName);
-        _showImportDialog = false;
-        _localModName = ""; _localModPath = "";
-        await RefreshMods();
-        Snackbar.Add("Mod imported successfully", Severity.Success);
+        try
+        {
+            await ModService.ImportLocalModAsync(_localModPath, _localModName);
+            _showImportDialog = false;
+            _localModName = ""; _localModPath = "";
+            await RefreshMods();
+            Snackbar.Add("Mod imported successfully", Severity.Success);
+        }
+        catch (Exception ex) { Snackbar.Add($"Import failed: {OutputSanitizer.SanitizeException(ex)}", Severity.Error); }
     }
 
     private async Task DownloadMod(SteamMod mod, CancellationToken parentCt = default)
@@ -917,7 +922,7 @@ else
         catch (Exception ex)
         {
             _taskProgress.Remove(mod.Id);
-            Snackbar.Add($"Download failed: {ex.Message}", Severity.Error);
+            Snackbar.Add($"Download failed: {OutputSanitizer.SanitizeException(ex)}", Severity.Error);
             await RefreshMods();
         }
         finally
@@ -958,7 +963,7 @@ else
                     : "All mods are up to date",
                 _outdatedCount > 0 ? Severity.Warning : Severity.Success);
         }
-        catch (Exception ex) { Snackbar.Add($"Check failed: {ex.Message}", Severity.Error); }
+        catch (Exception ex) { Snackbar.Add($"Check failed: {OutputSanitizer.SanitizeException(ex)}", Severity.Error); }
         finally { _isCheckingUpdates = false; }
     }
 
@@ -992,7 +997,7 @@ else
                 _ = DownloadMod(mod, _bulkUpdateCts.Token);
             Snackbar.Add($"Updating {pendingMods.Count} mod(s) in parallel…", Severity.Info);
         }
-        catch (Exception ex) { Snackbar.Add($"Update failed: {ex.Message}", Severity.Error); }
+        catch (Exception ex) { Snackbar.Add($"Update failed: {OutputSanitizer.SanitizeException(ex)}", Severity.Error); }
         finally
         {
             _isUpdatingAll = false;
@@ -1029,7 +1034,7 @@ else
                 isOutdated ? $"{mod.Name}: update available" : $"{mod.Name}: up to date",
                 isOutdated ? Severity.Warning : Severity.Success);
         }
-        catch (Exception ex) { Snackbar.Add($"Check failed: {ex.Message}", Severity.Error); }
+        catch (Exception ex) { Snackbar.Add($"Check failed: {OutputSanitizer.SanitizeException(ex)}", Severity.Error); }
         finally { _checkingMods.Remove(mod.Id); }
     }
 

--- a/src/KAST.UI/Components/Pages/ServerEdit.razor
+++ b/src/KAST.UI/Components/Pages/ServerEdit.razor
@@ -129,7 +129,7 @@
             var settings = await SettingsService.GetSettingsAsync();
             _serversDirectory = settings.ServersDirectory;
             _instance.Name = $"Server-{DateTime.UtcNow:yyyyMMdd-HHmmss}";
-            _instance.InstallPath = Path.Combine(_serversDirectory, _instance.Name);
+            _instance.InstallPath = BuildInstallPath(_serversDirectory, _instance.Name);
             _serverConfig.Hostname = _instance.Name;
         }
 
@@ -141,7 +141,19 @@
     private void OnNameChanged()
     {
         if (_isNew && !string.IsNullOrWhiteSpace(_instance.Name))
-            _instance.InstallPath = Path.Combine(_serversDirectory, _instance.Name);
+            _instance.InstallPath = BuildInstallPath(_serversDirectory, _instance.Name);
+    }
+
+    private static string BuildInstallPath(string serversDirectory, string serverName)
+    {
+        var safeName = serverName.Trim();
+        foreach (var invalidChar in Path.GetInvalidFileNameChars())
+            safeName = safeName.Replace(invalidChar, '_');
+        safeName = safeName
+            .Replace(Path.DirectorySeparatorChar, '_')
+            .Replace(Path.AltDirectorySeparatorChar, '_');
+
+        return Path.Join(serversDirectory, string.IsNullOrWhiteSpace(safeName) ? "Server" : safeName);
     }
 
     private void OnServerConfigChanged() => _serverCfgRaw = ConfigService.SerializeServerConfig(_serverConfig);

--- a/src/KAST.UI/Components/Pages/ServerEdit.razor
+++ b/src/KAST.UI/Components/Pages/ServerEdit.razor
@@ -4,6 +4,7 @@
 @inject IServerInstanceService ServerService
 @inject IServerConfigService ConfigService
 @inject ISettingsService SettingsService
+@inject IOutputSanitizer OutputSanitizer
 @inject ISnackbar Snackbar
 @inject NavigationManager Nav
 
@@ -48,8 +49,7 @@
                     ServerConfig="_serverConfig"
                     IsNew="_isNew"
                     OnNameChanged="OnNameChanged"
-                    OnServerConfigChanged="OnServerConfigChanged"
-                    GetCommandLinePreview="GetCommandLinePreview" />
+                    OnServerConfigChanged="OnServerConfigChanged" />
     </MudTabPanel>
 
     @* ════════════ SERVER CONFIG ════════════ *@
@@ -201,7 +201,7 @@
             _activeTab = 6; // Monitor tab
             StateHasChanged();
         }
-        catch (Exception ex) { Snackbar.Add($"Failed to launch: {ex.Message}", Severity.Error); }
+        catch (Exception ex) { Snackbar.Add($"Failed to launch: {OutputSanitizer.SanitizeException(ex)}", Severity.Error); }
     }
 
     private async Task StopServer()
@@ -213,15 +213,7 @@
             _instance = (await ServerService.GetInstanceByIdAsync(_instance.Id))!;
             Snackbar.Add("Server stopped", Severity.Success);
         }
-        catch (Exception ex) { Snackbar.Add($"Failed to stop: {ex.Message}", Severity.Error); }
-    }
-
-    private string GetCommandLinePreview()
-    {
-        _instance.ServerCfgContent = ConfigService.SerializeServerConfig(_serverConfig);
-        _instance.BasicCfgContent = ConfigService.SerializeBasicConfig(_basicConfig);
-        _instance.ArmaProfileContent = ConfigService.SerializeArma3Profile(_profileData);
-        return ServerService.GetCommandLine(_instance);
+        catch (Exception ex) { Snackbar.Add($"Failed to stop: {OutputSanitizer.SanitizeException(ex)}", Severity.Error); }
     }
 
     private static Color GetStatusColor(ServerInstanceStatus status) => status switch

--- a/src/KAST.UI/Components/Pages/ServerEditTabs/GeneralTab.razor
+++ b/src/KAST.UI/Components/Pages/ServerEditTabs/GeneralTab.razor
@@ -1,13 +1,10 @@
-@* General: basic settings, DLC, schedule, performance, launch command preview *@
+@* General: basic settings, DLC, schedule, performance *@
 
 <MudGrid Class="mt-3">
     <MudItem xs="12" sm="6">
         <MudTextField Value="@Instance.Name"
                       ValueChanged="@((string v) => { Instance.Name = v; _ = OnNameChanged.InvokeAsync(); })"
                       Label="Instance Name" FullWidth="true" />
-    </MudItem>
-    <MudItem xs="12" sm="6">
-        <MudTextField @bind-Value="Instance.InstallPath" Label="Install Path" FullWidth="true" />
     </MudItem>
     <MudItem xs="6" sm="3">
         <MudNumericField @bind-Value="Instance.Port" Label="Game Port" Min="1" Max="65535" />
@@ -97,31 +94,12 @@
     </MudItem>
 </MudGrid>
 
-@* Command line preview *@
-<div class="mt-4">
-    <div class="d-flex align-center gap-2 mb-1">
-        <MudText Typo="Typo.subtitle1">Launch Command</MudText>
-        <MudIconButton Icon="@(_cmdExpanded ? Icons.Material.Filled.ExpandLess : Icons.Material.Filled.ExpandMore)"
-                       Size="Size.Small" OnClick="@(() => _cmdExpanded = !_cmdExpanded)" />
-    </div>
-    @if (_cmdExpanded && GetCommandLinePreview != null)
-    {
-        <MudPaper Elevation="0" Class="pa-2"
-                  Style="background:var(--mud-palette-background-grey); font-family:monospace; font-size:12px; overflow-x:auto; word-break:break-all;">
-            @GetCommandLinePreview()
-        </MudPaper>
-    }
-</div>
-
 @code {
     [Parameter, EditorRequired] public ServerInstance Instance { get; set; } = default!;
     [Parameter, EditorRequired] public ServerConfigData ServerConfig { get; set; } = default!;
     [Parameter] public bool IsNew { get; set; }
     [Parameter] public EventCallback OnNameChanged { get; set; }
     [Parameter] public EventCallback OnServerConfigChanged { get; set; }
-    [Parameter] public Func<string>? GetCommandLinePreview { get; set; }
-
-    private bool _cmdExpanded;
 
     private string _restartPolicyStr
     {

--- a/src/KAST.UI/Components/Pages/ServerEditTabs/InstallTab.razor
+++ b/src/KAST.UI/Components/Pages/ServerEditTabs/InstallTab.razor
@@ -1,5 +1,6 @@
 @inject IContentOrchestrator ContentOrchestrator
 @inject ContentProgressTracker ContentTracker
+@inject IOutputSanitizer OutputSanitizer
 @inject ISettingsService SettingsService
 @inject IJSRuntime JS
 @inject IServerInstanceService ServerService
@@ -123,7 +124,7 @@
                                     }
                                     else if (step.Status == ContentStepStatus.Failed)
                                     {
-                                        <MudAlert Severity="Severity.Error" Dense="true">@(step.Error ?? "Step failed")</MudAlert>
+                                        <MudAlert Severity="Severity.Error" Dense="true">@(OutputSanitizer.Sanitize(step.Error) ?? "Step failed")</MudAlert>
                                     }
                                 </div>
                             </MudStep>
@@ -156,7 +157,7 @@
                      @ref="_installLogRef">
                     @foreach (var line in _installState.Log)
                     {
-                        <div>@line</div>
+                        <div>@OutputSanitizer.Sanitize(line)</div>
                     }
                 </div>
             </MudPaper>
@@ -201,7 +202,7 @@
                         <MudText Typo="Typo.body2">@r.Label</MudText>
                         @if (!string.IsNullOrEmpty(r.Detail))
                         {
-                            <MudText Typo="Typo.caption" Color="Color.Secondary">@r.Detail</MudText>
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">@OutputSanitizer.Sanitize(r.Detail)</MudText>
                         }
                     </div>
                 </div>
@@ -336,13 +337,13 @@
         });
     }
 
-    private static string? GetStepSecondaryText(ContentStep step) => step.Status switch
+    private string? GetStepSecondaryText(ContentStep step) => step.Status switch
     {
         ContentStepStatus.InProgress => step.IsIndeterminate ? "running\u2026" : $"{step.Progress:F0}%",
         ContentStepStatus.Completed  => "done",
-        ContentStepStatus.Failed     => step.Error ?? "failed",
+        ContentStepStatus.Failed     => OutputSanitizer.Sanitize(step.Error) ?? "failed",
         ContentStepStatus.Skipped    => "skipped",
-        _                            => step.Detail
+        _                            => OutputSanitizer.Sanitize(step.Detail)
     };
 
     public ValueTask DisposeAsync()

--- a/src/KAST.UI/Components/Pages/ServerEditTabs/ModsTab.razor
+++ b/src/KAST.UI/Components/Pages/ServerEditTabs/ModsTab.razor
@@ -13,6 +13,20 @@
                   Variant="Variant.Outlined"
                   Style="max-width:260px;" />
     <MudSpacer />
+    <MudButton StartIcon="@Icons.Material.Filled.RemoveCircleOutline"
+               Color="Color.Default" Variant="Variant.Outlined"
+               Size="Size.Small"
+               Disabled="@(!Instance.Mods.Any())"
+               OnClick="UnloadAllMods">
+        Unload All
+    </MudButton>
+    <MudButton StartIcon="@Icons.Material.Filled.DoneAll"
+               Color="Color.Info" Variant="Variant.Outlined"
+               Size="Size.Small"
+               Disabled="@(!UnassignedMods.Any())"
+               OnClick="LoadAllAvailableMods">
+        Load All
+    </MudButton>
     <MudButton StartIcon="@Icons.Material.Filled.PlaylistAdd"
                Color="Color.Secondary" Variant="Variant.Outlined"
                Size="Size.Small"
@@ -135,18 +149,18 @@
                 <MudCheckBox T="bool?" Value="@GetPresetSelectAllState()"
                              ValueChanged="@ToggleSelectAllPresetMods"
                              Dense="true" />
-                <MudText Typo="Typo.caption" Color="Color.Secondary">Select all new</MudText>
+                <MudText Typo="Typo.caption" Color="Color.Secondary">Select all preset mods</MudText>
             </div>
 
             <div style="max-height:260px; overflow-y:auto;">
                 @foreach (var (wid, dname) in _parsedPresetMods)
                 {
+                    bool alreadyClient = Instance.Mods.Any(m => m.IsClientSide && m.SteamMod?.WorkshopId == wid);
                     bool alreadyIn = Instance.Mods.Any(m => m.SteamMod?.WorkshopId == wid);
-                    <div class="d-flex align-center gap-1 py-1" style="@(alreadyIn ? "opacity:.55;" : "")">
+                    <div class="d-flex align-center gap-1 py-1" style="@(alreadyClient ? "opacity:.75;" : "")">
                         <MudCheckBox T="bool"
                                      Value="@(_presetSelectedIds.Contains(wid))"
                                      ValueChanged="@((v) => TogglePresetMod(wid, v))"
-                                     Disabled="@alreadyIn"
                                      Dense="true" />
                         <MudIcon Icon="@Icons.Material.Filled.Extension" Size="Size.Small"
                                  Style="opacity:.4; flex-shrink:0;" />
@@ -155,7 +169,7 @@
                         @if (alreadyIn)
                         {
                             <MudChip T="string" Size="Size.Small" Color="Color.Info"
-                                     Variant="Variant.Text">in instance</MudChip>
+                                     Variant="Variant.Text">loaded</MudChip>
                         }
                     </div>
                 }
@@ -175,9 +189,9 @@
     <DialogActions>
         <MudButton OnClick="ClosePresetImportDialog" Disabled="@_isImportingPreset">Cancel</MudButton>
         <MudButton Color="Color.Primary" Variant="Variant.Filled"
-                   Disabled="@(_presetSelectedIds.Count == 0 || _isImportingPreset)"
+                   Disabled="@(_parsedPresetMods.Count == 0 || _isImportingPreset)"
                    OnClick="ImportPresetToClient">
-            Add @_presetSelectedIds.Count mod(s)
+            Replace Clientside
         </MudButton>
     </DialogActions>
 </MudDialog>
@@ -324,6 +338,24 @@
         ReindexMods();
     }
 
+    private async Task UnloadAllMods()
+    {
+        foreach (var modId in Instance.Mods.Select(m => m.SteamModId).ToList())
+            await RemoveMod(modId);
+
+        BuildDragItems();
+        StateHasChanged();
+    }
+
+    private async Task LoadAllAvailableMods()
+    {
+        foreach (var mod in UnassignedMods.OrderBy(m => m.Name).ToList())
+            await AddMod(mod.Id, "client");
+
+        BuildDragItems();
+        StateHasChanged();
+    }
+
     private void ReindexMods()
     {
         int wi = 0; foreach (var m in Instance.Mods.Where(m => !m.IsClientSide && !m.IsServerSide).OrderBy(m => m.LoadOrder)) m.LoadOrder = wi++;
@@ -376,9 +408,7 @@
             _parsedPresetMods.Add((wid, displayName));
         }
 
-        _presetSelectedIds = [.. _parsedPresetMods
-            .Where(p => !Instance.Mods.Any(m => m.SteamMod?.WorkshopId == p.WorkshopId))
-            .Select(p => p.WorkshopId)];
+        _presetSelectedIds = [.. _parsedPresetMods.Select(p => p.WorkshopId)];
 
         StateHasChanged();
     }
@@ -391,69 +421,123 @@
 
     private bool? GetPresetSelectAllState()
     {
-        var newIds = _parsedPresetMods
-            .Where(p => !Instance.Mods.Any(m => m.SteamMod?.WorkshopId == p.WorkshopId))
-            .Select(p => p.WorkshopId)
-            .ToList();
-        if (newIds.Count == 0) return false;
-        int selected = newIds.Count(id => _presetSelectedIds.Contains(id));
+        var presetIds = _parsedPresetMods.Select(p => p.WorkshopId).ToList();
+        if (presetIds.Count == 0) return false;
+        int selected = presetIds.Count(id => _presetSelectedIds.Contains(id));
         if (selected == 0) return false;
-        return selected == newIds.Count ? true : null;
+        return selected == presetIds.Count ? true : null;
     }
 
     private void ToggleSelectAllPresetMods(bool? value)
     {
-        var newIds = _parsedPresetMods
-            .Where(p => !Instance.Mods.Any(m => m.SteamMod?.WorkshopId == p.WorkshopId))
-            .Select(p => p.WorkshopId);
+        var presetIds = _parsedPresetMods.Select(p => p.WorkshopId);
         if (value == true)
-            foreach (var id in newIds) _presetSelectedIds.Add(id);
+            foreach (var id in presetIds) _presetSelectedIds.Add(id);
         else
-            foreach (var id in newIds) _presetSelectedIds.Remove(id);
+            foreach (var id in presetIds) _presetSelectedIds.Remove(id);
     }
 
     private async Task ImportPresetToClient()
     {
         _isImportingPreset = true;
-        _presetImportTotal = _presetSelectedIds.Count;
+        var selectedPresetMods = _parsedPresetMods
+            .Where(p => _presetSelectedIds.Contains(p.WorkshopId))
+            .GroupBy(p => p.WorkshopId)
+            .Select(g => g.First())
+            .ToList();
+        var selectedWorkshopIds = selectedPresetMods
+            .Select(p => p.WorkshopId)
+            .ToHashSet();
+        var clientsToUnload = Instance.Mods
+            .Where(m => m.IsClientSide && (m.SteamMod == null || !selectedWorkshopIds.Contains(m.SteamMod.WorkshopId)))
+            .ToList();
+
+        _presetImportTotal = selectedPresetMods.Count + clientsToUnload.Count;
         _presetImportDone = 0;
         StateHasChanged();
 
-        var existingWorkshopIds = Instance.Mods
-            .Where(m => m.SteamMod != null)
-            .Select(m => m.SteamMod!.WorkshopId)
-            .ToHashSet();
+        var desiredClientMods = new List<SteamMod>();
 
-        foreach (var (workshopId, _) in _parsedPresetMods.Where(p => _presetSelectedIds.Contains(p.WorkshopId)))
+        foreach (var (workshopId, _) in selectedPresetMods)
         {
             try
             {
-                var mod = await ModService.AddWorkshopModAsync(workshopId);
+                var existingMod = Instance.Mods
+                    .FirstOrDefault(m => m.SteamMod?.WorkshopId == workshopId)
+                    ?.SteamMod;
+                var mod = existingMod ?? await ModService.AddWorkshopModAsync(workshopId);
 
                 if (!_availableMods.Any(m => m.Id == mod.Id))
                     _availableMods.Add(mod);
 
-                if (!existingWorkshopIds.Contains(workshopId))
-                {
-                    if (!IsNew)
-                        await ServerService.AddModToInstanceAsync(Instance.Id, mod.Id,
-                            isClientSide: true, isServerSide: false);
-
-                    Instance.Mods.Add(new ServerInstanceMod
-                    {
-                        SteamModId   = mod.Id,
-                        SteamMod     = mod,
-                        IsClientSide = true,
-                        IsServerSide = false,
-                        LoadOrder    = Instance.Mods.Count
-                    });
-                    existingWorkshopIds.Add(workshopId);
-                }
+                desiredClientMods.Add(mod);
             }
             catch { /* skip mods that fail to resolve */ }
 
             _presetImportDone++;
             StateHasChanged();
+        }
+
+        foreach (var clientMod in clientsToUnload)
+        {
+            if (clientMod.IsServerSide)
+            {
+                clientMod.IsClientSide = false;
+                if (!IsNew)
+                    await ServerService.UpdateModFlagsAsync(
+                        Instance.Id,
+                        clientMod.SteamModId,
+                        isClientSide: false,
+                        isServerSide: true);
+            }
+            else
+            {
+                await RemoveMod(clientMod.SteamModId);
+            }
+
+            _presetImportDone++;
+            StateHasChanged();
+        }
+
+        for (var index = 0; index < desiredClientMods.Count; index++)
+        {
+            var mod = desiredClientMods[index];
+            var existingLink = Instance.Mods.FirstOrDefault(m => m.SteamModId == mod.Id);
+            if (existingLink == null)
+            {
+                if (!IsNew)
+                    await ServerService.AddModToInstanceAsync(
+                        Instance.Id,
+                        mod.Id,
+                        index,
+                        isClientSide: true,
+                        isServerSide: false);
+
+                Instance.Mods.Add(new ServerInstanceMod
+                {
+                    SteamModId   = mod.Id,
+                    SteamMod     = mod,
+                    IsClientSide = true,
+                    IsServerSide = false,
+                    LoadOrder    = index
+                });
+            }
+            else
+            {
+                existingLink.IsClientSide = true;
+                existingLink.IsServerSide = false;
+                existingLink.LoadOrder = index;
+
+                if (!IsNew)
+                {
+                    await ServerService.UpdateModFlagsAsync(
+                        Instance.Id,
+                        mod.Id,
+                        isClientSide: true,
+                        isServerSide: false);
+                    await ServerService.UpdateModLoadOrderAsync(Instance.Id, mod.Id, index);
+                }
+            }
         }
 
         ReindexMods();

--- a/src/KAST.UI/Components/Pages/Servers.razor
+++ b/src/KAST.UI/Components/Pages/Servers.razor
@@ -1,5 +1,6 @@
 @page "/servers"
 @inject IServerInstanceService ServerService
+@inject IOutputSanitizer OutputSanitizer
 @inject ISnackbar Snackbar
 @inject NavigationManager Nav
 
@@ -89,20 +90,20 @@ else
     private async Task StartInstance(int id)
     {
         try { await ServerService.StartInstanceAsync(id); Nav.NavigateTo($"/servers/{id}"); }
-        catch (Exception ex) { Snackbar.Add($"Failed to start: {ex.Message}", Severity.Error); await RefreshInstances(); }
+        catch (Exception ex) { Snackbar.Add($"Failed to start: {OutputSanitizer.SanitizeException(ex)}", Severity.Error); await RefreshInstances(); }
     }
 
     private async Task StopInstance(int id)
     {
         try { await ServerService.StopInstanceAsync(id); Snackbar.Add("Server stopped", Severity.Success); }
-        catch (Exception ex) { Snackbar.Add($"Failed to stop: {ex.Message}", Severity.Error); }
+        catch (Exception ex) { Snackbar.Add($"Failed to stop: {OutputSanitizer.SanitizeException(ex)}", Severity.Error); }
         finally { await RefreshInstances(); }
     }
 
     private async Task RestartInstance(int id)
     {
         try { await ServerService.RestartInstanceAsync(id); Snackbar.Add("Server restarted", Severity.Success); }
-        catch (Exception ex) { Snackbar.Add($"Failed to restart: {ex.Message}", Severity.Error); }
+        catch (Exception ex) { Snackbar.Add($"Failed to restart: {OutputSanitizer.SanitizeException(ex)}", Severity.Error); }
         finally { await RefreshInstances(); }
     }
 

--- a/src/KAST.UI/Components/Pages/Settings.razor
+++ b/src/KAST.UI/Components/Pages/Settings.razor
@@ -3,6 +3,7 @@
 @inject IApiKeyService ApiKeyService
 @inject ISettingsService SettingsService
 @inject ISteamService SteamService
+@inject IOutputSanitizer OutputSanitizer
 @inject ISnackbar Snackbar
 @inject ThemeService ThemeService
 @inject NavigationManager Navigation
@@ -350,7 +351,7 @@
         if (!string.IsNullOrEmpty(session.ErrorMessage))
         {
             _loggingIn = false;
-            Snackbar.Add($"QR error: {session.ErrorMessage}", Severity.Error);
+            Snackbar.Add($"QR error: {OutputSanitizer.Sanitize(session.ErrorMessage)}", Severity.Error);
             StateHasChanged();
             return;
         }
@@ -383,7 +384,7 @@
         if (!string.IsNullOrEmpty(session.ErrorMessage))
         {
             _loggingIn = false;
-            Snackbar.Add($"Credential login error: {session.ErrorMessage}", Severity.Error);
+            Snackbar.Add($"Credential login error: {OutputSanitizer.Sanitize(session.ErrorMessage)}", Severity.Error);
             StateHasChanged();
             return;
         }
@@ -494,10 +495,10 @@
         {
             if (!SteamService.IsConnected)
             { _benchmarkStatus = "Connecting to Steam..."; StateHasChanged(); await SteamService.LoginAnonymousAsync(); }
-            var log = new Progress<string>(msg => InvokeAsync(() => { _benchmarkStatus = msg; StateHasChanged(); }));
+            var log = new Progress<string>(msg => InvokeAsync(() => { _benchmarkStatus = OutputSanitizer.Sanitize(msg); StateHasChanged(); }));
             _benchmarkResults = await SteamService.BenchmarkDownloadAsync(log);
         }
-        catch (Exception ex) { Snackbar.Add($"Benchmark failed: {ex.Message}", Severity.Error); }
+        catch (Exception ex) { Snackbar.Add($"Benchmark failed: {OutputSanitizer.SanitizeException(ex)}", Severity.Error); }
         finally { _benchmarkRunning = false; _benchmarkStatus = null; StateHasChanged(); }
     }
 

--- a/src/KAST.UI/KAST.UI.csproj
+++ b/src/KAST.UI/KAST.UI.csproj
@@ -18,6 +18,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />

--- a/src/KAST.UI/Program.cs
+++ b/src/KAST.UI/Program.cs
@@ -16,10 +16,11 @@ using OpenTelemetry.Trace;
 using ModStatus = KAST.Core.Enums.ModStatus;
 
 var builder = WebApplication.CreateBuilder(args);
+var contentRoot = builder.Environment.ContentRootPath;
 var outputSanitizer = new OutputSanitizer(
-    new OutputSanitizer.VirtualPathRoot(AppContext.BaseDirectory, "KAST"),
-    new OutputSanitizer.VirtualPathRoot(ResolveConfiguredPath(builder.Configuration["Kast:ModsDirectory"] ?? "./mods"), "mods"),
-    new OutputSanitizer.VirtualPathRoot(ResolveConfiguredPath(builder.Configuration["Kast:ServersDirectory"] ?? "./servers"), "server"));
+    new OutputSanitizer.VirtualPathRoot(contentRoot, "KAST"),
+    new OutputSanitizer.VirtualPathRoot(ResolveConfiguredPath(contentRoot, builder.Configuration["Kast:ModsDirectory"] ?? "./mods"), "mods"),
+    new OutputSanitizer.VirtualPathRoot(ResolveConfiguredPath(contentRoot, builder.Configuration["Kast:ServersDirectory"] ?? "./servers"), "server"));
 builder.Services.AddSingleton<IOutputSanitizer>(outputSanitizer);
 builder.Host.UseWindowsService(options =>
 {
@@ -204,6 +205,6 @@ _ = Task.Run(async () =>
 
 app.Run();
 
-static string ResolveConfiguredPath(string path) =>
-    Path.GetFullPath(Path.IsPathRooted(path) ? path : Path.Combine(AppContext.BaseDirectory, path));
+static string ResolveConfiguredPath(string contentRoot, string path) =>
+    Path.GetFullPath(Path.IsPathRooted(path) ? path : Path.Combine(contentRoot, path));
 

--- a/src/KAST.UI/Program.cs
+++ b/src/KAST.UI/Program.cs
@@ -2,6 +2,7 @@ using KAST.Core.Interfaces;
 using KAST.Infrastructure;
 using KAST.Infrastructure.Data;
 using KAST.Infrastructure.Steam;
+using KAST.Infrastructure.Services;
 using KAST.Infrastructure.Telemetry;
 using KAST.UI.Api;
 using KAST.UI.Components;
@@ -15,6 +16,11 @@ using OpenTelemetry.Trace;
 using ModStatus = KAST.Core.Enums.ModStatus;
 
 var builder = WebApplication.CreateBuilder(args);
+var outputSanitizer = new OutputSanitizer(
+    new OutputSanitizer.VirtualPathRoot(AppContext.BaseDirectory, "KAST"),
+    new OutputSanitizer.VirtualPathRoot(ResolveConfiguredPath(builder.Configuration["Kast:ModsDirectory"] ?? "./mods"), "mods"),
+    new OutputSanitizer.VirtualPathRoot(ResolveConfiguredPath(builder.Configuration["Kast:ServersDirectory"] ?? "./servers"), "server"));
+builder.Services.AddSingleton<IOutputSanitizer>(outputSanitizer);
 builder.Host.UseWindowsService(options =>
 {
     options.ServiceName = "KAST Panel";
@@ -23,7 +29,7 @@ builder.Host.UseWindowsService(options =>
 // ── In-memory log capture (UI console) ──────────────────────────────────────
 var kastLogStore = new KastLogStore();
 builder.Services.AddSingleton(kastLogStore);
-builder.Logging.AddProvider(new KastLoggerProvider(kastLogStore));
+builder.Logging.AddProvider(new KastLoggerProvider(kastLogStore, outputSanitizer));
 
 // ── Health checks ────────────────────────────────────────────────────────────
 builder.Services.AddHealthChecks()
@@ -73,7 +79,7 @@ if (telemetry.GetValue("Enabled", true))
     var serviceName  = telemetry["ServiceName"]  ?? KastActivitySources.ServiceName;
 
     // Attach ILogger calls as span events so they appear inside traces in Jaeger
-    builder.Logging.AddProvider(new ActivityEventLoggerProvider());
+    builder.Logging.AddProvider(new ActivityEventLoggerProvider(outputSanitizer));
 
     builder.Services.AddOpenTelemetry()
         .WithTracing(tracing => tracing
@@ -197,3 +203,7 @@ _ = Task.Run(async () =>
 });
 
 app.Run();
+
+static string ResolveConfiguredPath(string path) =>
+    Path.GetFullPath(Path.IsPathRooted(path) ? path : Path.Combine(AppContext.BaseDirectory, path));
+

--- a/src/KAST.UI/Program.cs
+++ b/src/KAST.UI/Program.cs
@@ -15,6 +15,10 @@ using OpenTelemetry.Trace;
 using ModStatus = KAST.Core.Enums.ModStatus;
 
 var builder = WebApplication.CreateBuilder(args);
+builder.Host.UseWindowsService(options =>
+{
+    options.ServiceName = "KAST Panel";
+});
 
 // ── In-memory log capture (UI console) ──────────────────────────────────────
 var kastLogStore = new KastLogStore();
@@ -193,4 +197,3 @@ _ = Task.Run(async () =>
 });
 
 app.Run();
-

--- a/src/KAST.UI/Services/ActivityEventLoggerProvider.cs
+++ b/src/KAST.UI/Services/ActivityEventLoggerProvider.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using KAST.Core.Interfaces;
 using Microsoft.Extensions.Logging;
 
 namespace KAST.UI.Services;
@@ -8,16 +9,16 @@ namespace KAST.UI.Services;
 /// that log messages are visible inside traces in Jaeger.
 /// Only wires up when there is an active span; has no effect otherwise.
 /// </summary>
-public sealed class ActivityEventLoggerProvider : ILoggerProvider
+public sealed class ActivityEventLoggerProvider(IOutputSanitizer sanitizer) : ILoggerProvider
 {
-    public ILogger CreateLogger(string categoryName) => new ActivityEventLogger(categoryName);
+    public ILogger CreateLogger(string categoryName) => new ActivityEventLogger(categoryName, sanitizer);
     public void Dispose()
     {
         // No unmanaged resources to release.
     }
 }
 
-file sealed class ActivityEventLogger(string categoryName) : ILogger
+file sealed class ActivityEventLogger(string categoryName, IOutputSanitizer sanitizer) : ILogger
 {
     // No span = no overhead; never block callers with actual I/O in this path.
     public bool IsEnabled(LogLevel logLevel) =>
@@ -34,14 +35,14 @@ file sealed class ActivityEventLogger(string categoryName) : ILogger
         var tags = new ActivityTagsCollection
         {
             ["log.severity"] = logLevel.ToString(),
-            ["log.message"]  = formatter(state, exception),
+            ["log.message"]  = sanitizer.Sanitize(formatter(state, exception)),
             ["log.category"] = categoryName
         };
 
         if (exception is not null)
         {
             tags["exception.type"]    = exception.GetType().Name;
-            tags["exception.message"] = exception.Message;
+            tags["exception.message"] = sanitizer.Sanitize(exception.Message);
         }
 
         activity.AddEvent(new ActivityEvent("log", tags: tags));

--- a/src/KAST.UI/Services/KastLoggerProvider.cs
+++ b/src/KAST.UI/Services/KastLoggerProvider.cs
@@ -1,10 +1,12 @@
+using KAST.Core.Interfaces;
+
 namespace KAST.UI.Services;
 
 [ProviderAlias("KastInMemory")]
-public sealed class KastLoggerProvider(KastLogStore store) : ILoggerProvider
+public sealed class KastLoggerProvider(KastLogStore store, IOutputSanitizer sanitizer) : ILoggerProvider
 {
     public ILogger CreateLogger(string categoryName) =>
-        new KastLogger(store, categoryName);
+        new KastLogger(store, sanitizer, categoryName);
 
     public void Dispose()
     {
@@ -12,7 +14,7 @@ public sealed class KastLoggerProvider(KastLogStore store) : ILoggerProvider
     }
 }
 
-internal sealed class KastLogger(KastLogStore store, string category) : ILogger
+internal sealed class KastLogger(KastLogStore store, IOutputSanitizer sanitizer, string category) : ILogger
 {
     public bool IsEnabled(LogLevel logLevel)
     {
@@ -32,9 +34,9 @@ internal sealed class KastLogger(KastLogStore store, string category) : ILogger
         if (!IsEnabled(logLevel)) 
             return;
 
-        var message = formatter(state, exception);
-        if (exception != null) 
-            message += $"\n{exception}";
+        var message = sanitizer.Sanitize(formatter(state, exception));
+        if (exception != null)
+            message += $"\n{sanitizer.SanitizeException(exception)}";
 
         store.Add(new AppLogEntry(DateTime.Now, logLevel, category, message));
     }

--- a/src/KAST.UI/Services/SignalREventBroadcaster.cs
+++ b/src/KAST.UI/Services/SignalREventBroadcaster.cs
@@ -11,7 +11,8 @@ namespace KAST.UI.Services;
 public class SignalREventBroadcaster(
     IHubContext<DownloadHub> downloadHub,
     IHubContext<MonitoringHub> monitoringHub,
-    ServerConsoleStore consoleStore) : IAppEventBroadcaster
+    ServerConsoleStore consoleStore,
+    IOutputSanitizer sanitizer) : IAppEventBroadcaster
 {
     public event Action<ModDownloadProgressEvent>? OnModDownloadProgress;
     public event Action<ModStatusChangedEvent>? OnModStatusChanged;
@@ -39,7 +40,8 @@ public class SignalREventBroadcaster(
 
     public Task BroadcastLogEntryAsync(LogEntryEvent logEntry)
     {
-        consoleStore.Add(logEntry);
-        return MonitoringHub.BroadcastLogEntry(monitoringHub, logEntry);
+        var safeLogEntry = logEntry with { Line = sanitizer.Sanitize(logEntry.Line) };
+        consoleStore.Add(safeLogEntry);
+        return MonitoringHub.BroadcastLogEntry(monitoringHub, safeLogEntry);
     }
 }

--- a/tests/KAST.Tests/CdnServerPoolTests.cs
+++ b/tests/KAST.Tests/CdnServerPoolTests.cs
@@ -1,3 +1,4 @@
+using KAST.Infrastructure.Services;
 using KAST.Infrastructure.Steam;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
@@ -19,7 +20,7 @@ public class CdnServerPoolTests
         Assert.NotNull(steamContent);
 
         var logger = Substitute.For<ILogger>();
-        using var pool = new CdnServerPool(steamClient, steamContent!, logger, parent.Token);
+        using var pool = new CdnServerPool(steamClient, steamContent!, logger, new OutputSanitizer(), parent.Token);
 
         var server = CreateServerStub();
         pool.ReturnServer(server, isFaulty: false);
@@ -40,7 +41,7 @@ public class CdnServerPoolTests
         Assert.NotNull(steamContent);
 
         var logger = Substitute.For<ILogger>();
-        using var pool = new CdnServerPool(steamClient, steamContent!, logger, parent.Token);
+        using var pool = new CdnServerPool(steamClient, steamContent!, logger, new OutputSanitizer(), parent.Token);
 
         var server = CreateServerStub();
         pool.ReturnServer(server, isFaulty: true);
@@ -62,7 +63,7 @@ public class CdnServerPoolTests
         Assert.NotNull(steamContent);
 
         var logger = Substitute.For<ILogger>();
-        using var pool = new CdnServerPool(steamClient, steamContent!, logger, parent.Token);
+        using var pool = new CdnServerPool(steamClient, steamContent!, logger, new OutputSanitizer(), parent.Token);
 
         using var cancelled = new CancellationTokenSource();
         cancelled.Cancel();

--- a/tests/KAST.Tests/ContentOrchestratorTests.cs
+++ b/tests/KAST.Tests/ContentOrchestratorTests.cs
@@ -3,6 +3,7 @@ using KAST.Core.Interfaces;
 using KAST.Core.Models;
 using KAST.Infrastructure.Data;
 using KAST.Infrastructure.Services.Content;
+using KAST.Infrastructure.Services;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -286,7 +287,7 @@ public class ContentOrchestratorTests
         var tracker = new ContentProgressTracker();
         var scopeFactory = provider.GetRequiredService<IServiceScopeFactory>();
         var logger = Substitute.For<ILogger<ContentOrchestrator>>();
-        return new ContentOrchestrator(scopeFactory, tracker, installers, logger);
+        return new ContentOrchestrator(scopeFactory, tracker, installers, logger, new OutputSanitizer());
     }
 
     private static ServiceProvider BuildServiceProvider(string? dbName = null)

--- a/tests/KAST.Tests/KastApiModsEndpointsTests.cs
+++ b/tests/KAST.Tests/KastApiModsEndpointsTests.cs
@@ -69,6 +69,86 @@ public class KastApiModsEndpointsTests
     }
 
     [Fact]
+    public async Task GetMods_SanitizesAbsoluteLocalPathInResponse()
+    {
+        var modService = Substitute.For<IModService>();
+        modService.GetAllModsAsync(Arg.Any<CancellationToken>()).Returns([
+            new SteamMod
+            {
+                Id = 1,
+                WorkshopId = EnhancedMovementWorkshopId,
+                Name = "ACE",
+                LocalPath = "C:\\Users\\secret\\mods\\@ace",
+                Status = ModStatus.Installed
+            }
+        ]);
+
+        await using var app = await CreateApiAppAsync(modService: modService);
+
+        var response = await app.Client.GetAsync("/api/mods/");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var json = await response.Content.ReadFromJsonAsync<List<Dictionary<string, object?>>>();
+        Assert.NotNull(json);
+        Assert.Single(json!);
+
+        var localPath = json[0]["localPath"]?.ToString();
+        Assert.False(string.IsNullOrWhiteSpace(localPath));
+        Assert.Equal("@ace", localPath);
+    }
+
+    [Fact]
+    public async Task GetServers_SanitizesAbsoluteInstallPathInResponse()
+    {
+        var serverService = Substitute.For<IServerInstanceService>();
+        serverService.GetAllInstancesAsync(Arg.Any<CancellationToken>()).Returns([
+            new ServerInstance
+            {
+                Id = 9,
+                Name = "Alpha",
+                InstallPath = "D:\\games\\arma\\servers\\alpha",
+                Mods = [],
+                HeadlessClients = []
+            }
+        ]);
+
+        await using var app = await CreateApiAppAsync(serverService: serverService);
+
+        var response = await app.Client.GetAsync("/api/servers/");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var json = await response.Content.ReadFromJsonAsync<List<Dictionary<string, object?>>>();
+        Assert.NotNull(json);
+        Assert.Single(json!);
+
+        var installPath = json[0]["installPath"]?.ToString();
+        Assert.False(string.IsNullOrWhiteSpace(installPath));
+        Assert.Equal("alpha", installPath);
+    }
+
+    [Fact]
+    public async Task GetSettings_SanitizesConfiguredDirectoriesInResponse()
+    {
+        var settingsService = Substitute.For<ISettingsService>();
+        settingsService.GetSettingsAsync(Arg.Any<CancellationToken>()).Returns(new KastSettings
+        {
+            ModsDirectory = "C:\\Users\\secret\\mods",
+            ServersDirectory = "D:\\private\\servers"
+        });
+
+        await using var app = await CreateApiAppAsync(settingsService: settingsService);
+
+        var response = await app.Client.GetAsync("/api/settings/");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var json = await response.Content.ReadFromJsonAsync<Dictionary<string, object?>>();
+        Assert.NotNull(json);
+
+        Assert.Equal("mods", json!["modsDirectory"]?.ToString());
+        Assert.Equal("servers", json["serversDirectory"]?.ToString());
+    }
+
+    [Fact]
     public async Task DownloadMod_WhenMissing_ReturnsNotFound()
     {
         var modService = Substitute.For<IModService>();
@@ -219,6 +299,7 @@ public class KastApiModsEndpointsTests
 
     private static async Task<ApiAppContext> CreateApiAppAsync(
         IModService? modService = null,
+        IServerInstanceService? serverService = null,
         IContentOrchestrator? orchestrator = null,
         ISettingsService? settingsService = null,
         IFileSystemService? fileSystemService = null,
@@ -232,7 +313,7 @@ public class KastApiModsEndpointsTests
         builder.WebHost.UseTestServer();
 
         builder.Services.AddSingleton(modService ?? Substitute.For<IModService>());
-        builder.Services.AddSingleton(Substitute.For<IServerInstanceService>());
+        builder.Services.AddSingleton(serverService ?? Substitute.For<IServerInstanceService>());
         builder.Services.AddSingleton(Substitute.For<IMonitoringService>());
         builder.Services.AddSingleton(Substitute.For<IApiKeyService>());
         builder.Services.AddSingleton(orchestrator ?? Substitute.For<IContentOrchestrator>());

--- a/tests/KAST.Tests/KastApiModsEndpointsTests.cs
+++ b/tests/KAST.Tests/KastApiModsEndpointsTests.cs
@@ -5,6 +5,7 @@ using KAST.Core.Events;
 using KAST.Core.Interfaces;
 using KAST.Core.Models;
 using KAST.UI.Api;
+using KAST.Infrastructure.Services;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
@@ -238,6 +239,7 @@ public class KastApiModsEndpointsTests
         builder.Services.AddSingleton(settingsService ?? BuildDefaultSettingsService());
         builder.Services.AddSingleton(fileSystemService ?? Substitute.For<IFileSystemService>());
         builder.Services.AddSingleton(broadcaster ?? BuildDefaultBroadcaster());
+        builder.Services.AddSingleton<IOutputSanitizer, OutputSanitizer>();
 
         var app = builder.Build();
         app.MapGroup("/api").MapKastApi();

--- a/tests/KAST.Tests/LocalModInstallerTests.cs
+++ b/tests/KAST.Tests/LocalModInstallerTests.cs
@@ -1,6 +1,7 @@
 using KAST.Core.Enums;
 using KAST.Core.Interfaces;
 using KAST.Core.Models;
+using KAST.Infrastructure.Services;
 using KAST.Infrastructure.Services.Content;
 using NSubstitute;
 
@@ -9,6 +10,8 @@ namespace KAST.Tests;
 public class LocalModInstallerTests : IDisposable
 {
     private readonly string _root = Path.Combine(Path.GetTempPath(), $"kast-local-installer-tests-{Guid.NewGuid():N}");
+
+    private static OutputSanitizer Sanitizer() => new();
 
     public LocalModInstallerTests()
     {
@@ -31,7 +34,7 @@ public class LocalModInstallerTests : IDisposable
     public void PlanSteps_Zip_IncludesExtractAndSize()
     {
         var fs = Substitute.For<IFileSystemService>();
-        var sut = new LocalModInstaller(fs);
+        var sut = new LocalModInstaller(fs, Sanitizer());
 
         var steps = sut.PlanSteps(new ContentInstallRequest
         {
@@ -49,7 +52,7 @@ public class LocalModInstallerTests : IDisposable
     public void PlanSteps_Folder_IncludesOnlySize()
     {
         var fs = Substitute.For<IFileSystemService>();
-        var sut = new LocalModInstaller(fs);
+        var sut = new LocalModInstaller(fs, Sanitizer());
 
         var steps = sut.PlanSteps(new ContentInstallRequest
         {
@@ -74,7 +77,7 @@ public class LocalModInstallerTests : IDisposable
                 return Task.CompletedTask;
             });
 
-        var sut = new LocalModInstaller(fs);
+        var sut = new LocalModInstaller(fs, Sanitizer());
 
         var request = new ContentInstallRequest
         {
@@ -104,7 +107,7 @@ public class LocalModInstallerTests : IDisposable
         var fs = Substitute.For<IFileSystemService>();
         fs.GetDirectorySize(Arg.Any<string>()).Returns(2048L);
 
-        var sut = new LocalModInstaller(fs);
+        var sut = new LocalModInstaller(fs, Sanitizer());
 
         var request = new ContentInstallRequest
         {
@@ -135,7 +138,7 @@ public class LocalModInstallerTests : IDisposable
         var fs = Substitute.For<IFileSystemService>();
         fs.GetDirectorySize(Arg.Any<string>()).Returns(4096L);
 
-        var sut = new LocalModInstaller(fs);
+        var sut = new LocalModInstaller(fs, Sanitizer());
         var path = Path.Combine(_root, "mod-dir");
         Directory.CreateDirectory(path);
 
@@ -153,7 +156,7 @@ public class LocalModInstallerTests : IDisposable
     public void Validate_WhenDirectoryMissing_ReturnsSingleFailure()
     {
         var fs = Substitute.For<IFileSystemService>();
-        var sut = new LocalModInstaller(fs);
+        var sut = new LocalModInstaller(fs, Sanitizer());
 
         var results = sut.Validate(new ContentInstallRequest
         {

--- a/tests/KAST.Tests/ModServiceTests.cs
+++ b/tests/KAST.Tests/ModServiceTests.cs
@@ -29,7 +29,7 @@ public class ModServiceTests : IDisposable
             .Returns(new KastSettings { ModsDirectory = ".KAST_DATA/mods" });
         _broadcaster = Substitute.For<IAppEventBroadcaster>();
         _logger = Substitute.For<ILogger<ModService>>();
-        _sut = new ModService(_db, _steamService, _settingsService, _broadcaster, _logger);
+        _sut = new ModService(_db, _steamService, _settingsService, _broadcaster, _logger, new OutputSanitizer());
     }
 
     ~ModServiceTests()

--- a/tests/KAST.Tests/OutputSanitizerTests.cs
+++ b/tests/KAST.Tests/OutputSanitizerTests.cs
@@ -1,0 +1,210 @@
+using KAST.Infrastructure.Services;
+
+namespace KAST.Tests;
+
+public class OutputSanitizerTests
+{
+    [Theory]
+    [InlineData("Failed to read C:\\servers\\arma\\server.cfg", "server.cfg")]
+    [InlineData("Failed to read C:/servers/arma/server.cfg", "server.cfg")]
+    [InlineData("Failed to read \\\\nas01\\share\\server.cfg", "server.cfg")]
+    [InlineData("Failed to read /home/kast/servers/server.cfg", "server.cfg")]
+    [InlineData("Failed to read ~/kast/servers/server.cfg", "server.cfg")]
+    [InlineData("Failed to read file:///C:/servers/arma/server.cfg", "server.cfg")]
+    public void Sanitize_StripsPathRootsAndKeepsRelativeContext(string message, string expectedRelativePath)
+    {
+        var sanitizer = new OutputSanitizer();
+
+        var sanitized = sanitizer.Sanitize(message);
+
+        Assert.Contains(expectedRelativePath, sanitized);
+        Assert.DoesNotContain("servers/arma", sanitized);
+        Assert.DoesNotContain("share/", sanitized);
+        Assert.DoesNotContain("<path>", sanitized);
+        AssertNoAbsoluteRoot(sanitized);
+    }
+
+    [Fact]
+    public void ToDisplayPath_StripsRootAndPreservesKnownFolderSuffix()
+    {
+        var sanitizer = new OutputSanitizer("D:/games/KAST");
+
+        var displayPath = sanitizer.ToDisplayPath("D:\\games\\KAST\\servers\\alpha\\arma3server_x64.exe");
+
+        Assert.Equal("servers/alpha/arma3server_x64.exe", displayPath);
+        AssertNoAbsoluteRoot(displayPath);
+    }
+
+    [Fact]
+    public void Sanitize_RewritesWindowsStackTracePathToRelativeFile()
+    {
+        var sanitizer = new OutputSanitizer();
+        var message = "   at KAST.Service.Run() in C:\\src\\KAST\\Service.cs:line 42";
+
+        var sanitized = sanitizer.Sanitize(message);
+
+        Assert.Contains("in Service.cs:line 42", sanitized);
+        AssertNoAbsoluteRoot(sanitized);
+    }
+
+    [Fact]
+    public void SanitizeException_UsesTypeAndSanitizedMessageOnly()
+    {
+        var sanitizer = new OutputSanitizer();
+        var exception = new InvalidOperationException("Could not access C:\\servers\\arma\\server.cfg");
+
+        var sanitized = sanitizer.SanitizeException(exception);
+
+        Assert.StartsWith("InvalidOperationException:", sanitized);
+        Assert.Contains("server.cfg", sanitized);
+        Assert.DoesNotContain("servers/arma", sanitized);
+        AssertNoAbsoluteRoot(sanitized);
+    }
+
+    [Fact]
+    public void ToDisplayPath_StripsRootsForConfiguredKastFolders()
+    {
+        var sanitizer = new OutputSanitizer(
+            new OutputSanitizer.VirtualPathRoot("C:/apps/KAST", "KAST"),
+            new OutputSanitizer.VirtualPathRoot("C:/apps/KAST/.KAST_DATA/mods", "mods"),
+            new OutputSanitizer.VirtualPathRoot("D:/server/Arma3/KAST/server", "server"));
+
+        Assert.Equal("KAST/README.md", sanitizer.ToDisplayPath("C:/apps/KAST/README.md"));
+        Assert.Equal("mods/@ace/addons/ace_main.pbo", sanitizer.ToDisplayPath("C:/apps/KAST/.KAST_DATA/mods/@ace/addons/ace_main.pbo"));
+        Assert.Equal("server/Server1/arma3server_x64.exe", sanitizer.ToDisplayPath("D:/server/Arma3/KAST/server/Server1/arma3server_x64.exe"));
+    }
+
+    [Fact]
+    public void ToDisplayPath_UnknownAbsolutePathOnlyShowsSafeFileName()
+    {
+        var sanitizer = new OutputSanitizer("C:/apps/KAST/.KAST_DATA/mods");
+
+        var displayPath = sanitizer.ToDisplayPath("E:/random/user/private/secret.cfg");
+
+        Assert.Equal("secret.cfg", displayPath);
+        Assert.DoesNotContain("random", displayPath);
+        Assert.DoesNotContain("private", displayPath);
+        AssertNoAbsoluteRoot(displayPath);
+    }
+
+    [Fact]
+    public void ToDisplayPath_VirtualRootPreventsTraversalEscapeDisclosure()
+    {
+        var sanitizer = new OutputSanitizer(new OutputSanitizer.VirtualPathRoot("C:/apps/KAST/.KAST_DATA/mods", "mods"));
+
+        var displayPath = sanitizer.ToDisplayPath("C:/apps/KAST/.KAST_DATA/mods/../../private/token.txt");
+
+        Assert.Equal("token.txt", displayPath);
+        Assert.DoesNotContain("private", displayPath);
+        Assert.DoesNotContain("..", displayPath);
+        AssertNoAbsoluteRoot(displayPath);
+    }
+
+    [Theory]
+    [InlineData("../secrets/config.json", "secrets/config.json")]
+    [InlineData("mods/@ace/../@cba/addons/cba_main.pbo", "mods/@cba/addons/cba_main.pbo")]
+    public void ToDisplayPath_NormalizesRelativeTraversalWithoutLeakingParentFolders(string input, string expected)
+    {
+        var sanitizer = new OutputSanitizer(
+            "C:/apps/KAST",
+            "C:/apps/KAST/.KAST_DATA/mods",
+            "D:/server/Arma3/KAST/server");
+
+        var displayPath = sanitizer.ToDisplayPath(input);
+
+        Assert.Equal(expected, displayPath);
+        Assert.DoesNotContain("..", displayPath);
+        AssertNoAbsoluteRoot(displayPath);
+    }
+
+    [Fact]
+    public void Sanitize_RewritesConfiguredKastFolderPaths()
+    {
+        var sanitizer = new OutputSanitizer(
+            new OutputSanitizer.VirtualPathRoot("C:/apps/KAST", "KAST"),
+            new OutputSanitizer.VirtualPathRoot("C:/apps/KAST/.KAST_DATA/mods", "mods"),
+            new OutputSanitizer.VirtualPathRoot("D:/server/Arma3/KAST/server", "server"));
+        var message = "Read C:/apps/KAST/README.md, C:/apps/KAST/.KAST_DATA/mods/@ace/addons/ace_main.pbo and D:/server/Arma3/KAST/server/Server1/arma3server_x64.exe";
+
+        var sanitized = sanitizer.Sanitize(message);
+
+        Assert.Contains("KAST/README.md", sanitized);
+        Assert.Contains("mods/@ace/addons/ace_main.pbo", sanitized);
+        Assert.Contains("Server1/arma3server_x64.exe", sanitized);
+        Assert.DoesNotContain("Arma3/KAST/server", sanitized);
+        AssertNoAbsoluteRoot(sanitized);
+    }
+
+    [Fact]
+    public void ToDisplayPath_SymlinkTargetInsideVirtualRootsKeepsLexicalDisplayPath()
+    {
+        var sanitizer = new OutputSanitizer(
+            path => path.Equals("D:/server/Arma3/KAST/server/Server1/mods/@ace/addons/ace_main.pbo", StringComparison.OrdinalIgnoreCase)
+                ? "C:/apps/KAST/.KAST_DATA/mods/@ace/addons/ace_main.pbo"
+                : null,
+            new OutputSanitizer.VirtualPathRoot("C:/apps/KAST/.KAST_DATA/mods", "mods"),
+            new OutputSanitizer.VirtualPathRoot("D:/server/Arma3/KAST/server", "server"));
+
+        var displayPath = sanitizer.ToDisplayPath("D:/server/Arma3/KAST/server/Server1/mods/@ace/addons/ace_main.pbo");
+
+        Assert.Equal("server/Server1/mods/@ace/addons/ace_main.pbo", displayPath);
+        AssertNoAbsoluteRoot(displayPath);
+    }
+
+    [Fact]
+    public void ToDisplayPath_ExternalSymlinkTargetOutsideVirtualRootsFallsBackToFileName()
+    {
+        var sanitizer = new OutputSanitizer(
+            path => path.Equals("D:/server/Arma3/KAST/server/Server1/mods/@evil/token.txt", StringComparison.OrdinalIgnoreCase)
+                ? "C:/Users/Admin/secrets/token.txt"
+                : null,
+            new OutputSanitizer.VirtualPathRoot("C:/apps/KAST/.KAST_DATA/mods", "mods"),
+            new OutputSanitizer.VirtualPathRoot("D:/server/Arma3/KAST/server", "server"));
+
+        var displayPath = sanitizer.ToDisplayPath("D:/server/Arma3/KAST/server/Server1/mods/@evil/token.txt");
+
+        Assert.Equal("token.txt", displayPath);
+        Assert.DoesNotContain("Users", displayPath);
+        Assert.DoesNotContain("secrets", displayPath);
+        Assert.DoesNotContain("server/Server1", displayPath);
+        AssertNoAbsoluteRoot(displayPath);
+    }
+
+    [Fact]
+    public void ToDisplayPath_UnresolvableSymlinkUsesLexicalVirtualRootDisplayPath()
+    {
+        var sanitizer = new OutputSanitizer(
+            _ => throw new IOException("broken link"),
+            new OutputSanitizer.VirtualPathRoot("D:/server/Arma3/KAST/server", "server"));
+
+        var displayPath = sanitizer.ToDisplayPath("D:/server/Arma3/KAST/server/Server1/@ace");
+
+        Assert.Equal("server/Server1/@ace", displayPath);
+        AssertNoAbsoluteRoot(displayPath);
+    }
+
+    [Fact]
+    public void ToDisplayPath_VirtualRootPrefixCollisionDoesNotMatch()
+    {
+        var sanitizer = new OutputSanitizer(new OutputSanitizer.VirtualPathRoot("C:/apps/KAST", "KAST"));
+
+        var displayPath = sanitizer.ToDisplayPath("C:/apps/KAST_backup/private/secret.txt");
+
+        Assert.Equal("secret.txt", displayPath);
+        Assert.DoesNotContain("KAST_backup", displayPath);
+        Assert.DoesNotContain("private", displayPath);
+        AssertNoAbsoluteRoot(displayPath);
+    }
+
+    private static void AssertNoAbsoluteRoot(string value)
+    {
+        Assert.DoesNotContain("C:\\", value);
+        Assert.DoesNotContain("D:\\", value);
+        Assert.DoesNotContain("C:/", value);
+        Assert.DoesNotContain("D:/", value);
+        Assert.DoesNotContain("\\\\nas01", value);
+        Assert.DoesNotContain("/home/", value);
+        Assert.DoesNotContain("~/", value);
+        Assert.DoesNotContain("file:///", value);
+    }
+}

--- a/tests/KAST.Tests/OutputSanitizerTests.cs
+++ b/tests/KAST.Tests/OutputSanitizerTests.cs
@@ -75,6 +75,17 @@ public class OutputSanitizerTests
     }
 
     [Fact]
+    public void ToDisplayPath_ConfiguredKastDataModsRootMapsToModsVirtualPath()
+    {
+        var sanitizer = new OutputSanitizer(new OutputSanitizer.VirtualPathRoot("G:/KAST/src/KAST.UI/.KAST_DATA/mods", "mods"));
+
+        var displayPath = sanitizer.ToDisplayPath("G:\\KAST\\src\\KAST.UI\\.KAST_DATA\\mods\\463939057");
+
+        Assert.Equal("mods/463939057", displayPath);
+        AssertNoAbsoluteRoot(displayPath);
+    }
+
+    [Fact]
     public void ToDisplayPath_UnknownAbsolutePathOnlyShowsSafeFileName()
     {
         var sanitizer = new OutputSanitizer("C:/apps/KAST/.KAST_DATA/mods");

--- a/tests/KAST.Tests/ServerInstallerTests.cs
+++ b/tests/KAST.Tests/ServerInstallerTests.cs
@@ -1,6 +1,7 @@
 using KAST.Core.Enums;
 using KAST.Core.Interfaces;
 using KAST.Core.Models;
+using KAST.Infrastructure.Services;
 using KAST.Infrastructure.Services.Content;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
@@ -17,7 +18,7 @@ public class ServerInstallerTests
         var steam = Substitute.For<ISteamService>();
         var fs = Substitute.For<IFileSystemService>();
         var logger = Substitute.For<ILogger<ServerInstaller>>();
-        var sut = new ServerInstaller(steam, fs, Substitute.For<IHttpClientFactory>(), logger);
+        var sut = new ServerInstaller(steam, fs, Substitute.For<IHttpClientFactory>(), logger, new OutputSanitizer());
 
         var steps = sut.PlanSteps(new ContentInstallRequest
         {
@@ -36,7 +37,7 @@ public class ServerInstallerTests
         var steam = Substitute.For<ISteamService>();
         var fs = Substitute.For<IFileSystemService>();
         var logger = Substitute.For<ILogger<ServerInstaller>>();
-        var sut = new ServerInstaller(steam, fs, Substitute.For<IHttpClientFactory>(), logger);
+        var sut = new ServerInstaller(steam, fs, Substitute.For<IHttpClientFactory>(), logger, new OutputSanitizer());
 
         var instance = new ServerInstance
         {
@@ -72,7 +73,7 @@ public class ServerInstallerTests
 
         var fs = Substitute.For<IFileSystemService>();
         var logger = Substitute.For<ILogger<ServerInstaller>>();
-        var sut = new ServerInstaller(steam, fs, Substitute.For<IHttpClientFactory>(), logger);
+        var sut = new ServerInstaller(steam, fs, Substitute.For<IHttpClientFactory>(), logger, new OutputSanitizer());
 
         var instance = new ServerInstance { Id = 10, Name = "Srv" };
         var request = new ContentInstallRequest
@@ -101,7 +102,7 @@ public class ServerInstallerTests
         var steam = Substitute.For<ISteamService>();
         var fs = Substitute.For<IFileSystemService>();
         var logger = Substitute.For<ILogger<ServerInstaller>>();
-        var sut = new ServerInstaller(steam, fs, Substitute.For<IHttpClientFactory>(), logger);
+        var sut = new ServerInstaller(steam, fs, Substitute.For<IHttpClientFactory>(), logger, new OutputSanitizer());
 
         var request = new ContentInstallRequest
         {
@@ -140,7 +141,7 @@ public class ServerInstallerTests
 
         var fs = Substitute.For<IFileSystemService>();
         var logger = Substitute.For<ILogger<ServerInstaller>>();
-        var sut = new ServerInstaller(steam, fs, Substitute.For<IHttpClientFactory>(), logger);
+        var sut = new ServerInstaller(steam, fs, Substitute.For<IHttpClientFactory>(), logger, new OutputSanitizer());
 
         var instance = new ServerInstance
         {
@@ -192,7 +193,7 @@ public class ServerInstallerTests
         var steam = Substitute.For<ISteamService>();
         var fs = Substitute.For<IFileSystemService>();
         var logger = Substitute.For<ILogger<ServerInstaller>>();
-        var sut = new ServerInstaller(steam, fs, Substitute.For<IHttpClientFactory>(), logger);
+        var sut = new ServerInstaller(steam, fs, Substitute.For<IHttpClientFactory>(), logger, new OutputSanitizer());
 
         var results = sut.Validate(new ContentInstallRequest
         {
@@ -230,7 +231,7 @@ public class ServerInstallerTests
             var steam = Substitute.For<ISteamService>();
             var fs = Substitute.For<IFileSystemService>();
             var logger = Substitute.For<ILogger<ServerInstaller>>();
-            var sut = new ServerInstaller(steam, fs, Substitute.For<IHttpClientFactory>(), logger);
+            var sut = new ServerInstaller(steam, fs, Substitute.For<IHttpClientFactory>(), logger, new OutputSanitizer());
 
             var results = sut.Validate(new ContentInstallRequest
             {

--- a/tests/KAST.Tests/ServerInstanceServiceTests.cs
+++ b/tests/KAST.Tests/ServerInstanceServiceTests.cs
@@ -200,6 +200,53 @@ public class ServerInstanceServiceTests : IDisposable
     }
 
     [Fact]
+    public void GetCommandLine_UsesAbsolutePerInstancePathsForArmaPathArguments()
+    {
+        var relativeInstallPath = Path.Combine("servers", "Server-20260528-202725");
+        var instance = new ServerInstance
+        {
+            Id = 2,
+            InstallPath = relativeInstallPath,
+            Port = 2302,
+            ServerCfgContent = "BattlEye = 0;",
+            BasicCfgContent = """
+                              // KAST Basic Server Configuration
+
+                              viewDistance = 2000;
+                              terrainGrid = 25;
+                              MaxMsgSend = 128;
+                              MaxSizeGuaranteed = 512;
+                              MaxSizeNonguaranteed = 256;
+                              MinBandwidth = 131072;
+                              MaxBandwidth = 10000000000;
+                              MinErrorToSend = 0.001;
+                              MinErrorToSendNear = 0.01;
+                              MaxCustomFileSize = 1024;
+                              class sockets
+                              {
+                                  maxPacketSize = 1400;
+                              };
+                              """
+        };
+
+        var commandLine = _sut.GetCommandLine(instance);
+
+        var fullInstallPath = Path.GetFullPath(relativeInstallPath);
+        var configDir = Path.Combine(fullInstallPath, "KAST", instance.Id.ToString());
+        var executableName = OperatingSystem.IsWindows()
+            ? "arma3server_x64.exe"
+            : "arma3server_x64";
+
+        Assert.StartsWith(Path.Combine(fullInstallPath, executableName), commandLine);
+        if (!OperatingSystem.IsLinux())
+            Assert.Contains($"\"-profiles={configDir}\"", commandLine);
+        Assert.Contains($"\"-config={Path.Combine(configDir, "server.cfg")}\"", commandLine);
+        Assert.Contains($"\"-cfg={Path.Combine(configDir, "basic.cfg")}\"", commandLine);
+        Assert.DoesNotContain($"-config={relativeInstallPath}", commandLine);
+        Assert.DoesNotContain($"-cfg={relativeInstallPath}", commandLine);
+    }
+
+    [Fact]
     public async Task StartInstance_ProcessFails_SetsCrashedStatus()
     {
         var instance = await SeedInstanceAsync();

--- a/tests/KAST.Tests/ServerInstanceServiceTests.cs
+++ b/tests/KAST.Tests/ServerInstanceServiceTests.cs
@@ -25,7 +25,7 @@ public class ServerInstanceServiceTests : IDisposable
         _processManager = Substitute.For<IProcessManagerService>();
         _broadcaster = Substitute.For<IAppEventBroadcaster>();
         _logger = Substitute.For<ILogger<ServerInstanceService>>();
-        _sut = new ServerInstanceService(_db, _processManager, _broadcaster, _logger);
+        _sut = new ServerInstanceService(_db, _processManager, _broadcaster, _logger, new OutputSanitizer());
     }
 
     public void Dispose()

--- a/tests/KAST.Tests/ServerInstanceServiceTests.cs
+++ b/tests/KAST.Tests/ServerInstanceServiceTests.cs
@@ -209,6 +209,7 @@ public class ServerInstanceServiceTests : IDisposable
             InstallPath = relativeInstallPath,
             Port = 2302,
             ServerCfgContent = "BattlEye = 0;",
+            ArmaProfileContent = "class DifficultyPresets {};",
             BasicCfgContent = """
                               // KAST Basic Server Configuration
 
@@ -231,7 +232,7 @@ public class ServerInstanceServiceTests : IDisposable
 
         var commandLine = _sut.GetCommandLine(instance);
 
-        var fullInstallPath = Path.GetFullPath(relativeInstallPath);
+        var fullInstallPath = Path.GetFullPath(relativeInstallPath, AppContext.BaseDirectory);
         var configDir = Path.Combine(fullInstallPath, "KAST", instance.Id.ToString());
         var executableName = OperatingSystem.IsWindows()
             ? "arma3server_x64.exe"

--- a/tests/KAST.Tests/SteamModInstallerTests.cs
+++ b/tests/KAST.Tests/SteamModInstallerTests.cs
@@ -2,6 +2,7 @@ using KAST.Core.Enums;
 using KAST.Core.Interfaces;
 using KAST.Core.Models;
 using KAST.Infrastructure.Services.Content;
+using KAST.Infrastructure.Services;
 using NSubstitute;
 
 namespace KAST.Tests;
@@ -13,7 +14,7 @@ public class SteamModInstallerTests
     {
         var steam = Substitute.For<ISteamService>();
         var fs = Substitute.For<IFileSystemService>();
-        var sut = new SteamModInstaller(steam, fs);
+        var sut = new SteamModInstaller(steam, fs, new OutputSanitizer());
 
         var steps = sut.PlanSteps(new ContentInstallRequest
         {
@@ -35,7 +36,7 @@ public class SteamModInstallerTests
         steam.LoginAnonymousAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult(false));
 
         var fs = Substitute.For<IFileSystemService>();
-        var sut = new SteamModInstaller(steam, fs);
+        var sut = new SteamModInstaller(steam, fs, new OutputSanitizer());
 
         var request = new ContentInstallRequest
         {
@@ -71,7 +72,7 @@ public class SteamModInstallerTests
         var fs = Substitute.For<IFileSystemService>();
         fs.GetDirectorySize("/tmp/mod").Returns(8192L);
 
-        var sut = new SteamModInstaller(steam, fs);
+        var sut = new SteamModInstaller(steam, fs, new OutputSanitizer());
 
         var request = new ContentInstallRequest
         {
@@ -111,7 +112,7 @@ public class SteamModInstallerTests
         var fs = Substitute.For<IFileSystemService>();
         fs.GetDirectorySize("/tmp/mod").Returns(1234L);
 
-        var sut = new SteamModInstaller(steam, fs);
+        var sut = new SteamModInstaller(steam, fs, new OutputSanitizer());
         var request = new ContentInstallRequest
         {
             Type = ContentType.SteamMod,
@@ -139,7 +140,7 @@ public class SteamModInstallerTests
     {
         var steam = Substitute.For<ISteamService>();
         var fs = Substitute.For<IFileSystemService>();
-        var sut = new SteamModInstaller(steam, fs);
+        var sut = new SteamModInstaller(steam, fs, new OutputSanitizer());
 
         var results = sut.Validate(new ContentInstallRequest
         {
@@ -161,7 +162,7 @@ public class SteamModInstallerTests
             var steam = Substitute.For<ISteamService>();
             var fs = Substitute.For<IFileSystemService>();
             fs.GetDirectorySize(path).Returns(5555L);
-            var sut = new SteamModInstaller(steam, fs);
+            var sut = new SteamModInstaller(steam, fs, new OutputSanitizer());
 
             var results = sut.Validate(new ContentInstallRequest
             {

--- a/tests/KAST.Tests/SteamWebApiClientTests.cs
+++ b/tests/KAST.Tests/SteamWebApiClientTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Text;
+using KAST.Infrastructure.Services;
 using KAST.Infrastructure.Steam;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
@@ -14,7 +15,7 @@ public class SteamWebApiClientTests
         var handler = new RecordingHandler((_, _) =>
             Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)));
         var client = new HttpClient(handler);
-        var sut = new SteamWebApiClient(client, Substitute.For<ILogger<SteamWebApiClient>>());
+        var sut = new SteamWebApiClient(client, Substitute.For<ILogger<SteamWebApiClient>>(), new OutputSanitizer());
 
         var result = await sut.GetPublishedFileDetailsBatchAsync([]);
 
@@ -67,7 +68,7 @@ public class SteamWebApiClientTests
         });
 
         var client = new HttpClient(handler);
-        var sut = new SteamWebApiClient(client, Substitute.For<ILogger<SteamWebApiClient>>());
+        var sut = new SteamWebApiClient(client, Substitute.For<ILogger<SteamWebApiClient>>(), new OutputSanitizer());
 
         var result = await sut.GetPublishedFileDetailsBatchAsync([333310405]);
 
@@ -110,7 +111,7 @@ public class SteamWebApiClientTests
             }));
 
         var client = new HttpClient(handler);
-        var sut = new SteamWebApiClient(client, Substitute.For<ILogger<SteamWebApiClient>>());
+        var sut = new SteamWebApiClient(client, Substitute.For<ILogger<SteamWebApiClient>>(), new OutputSanitizer());
 
         var result = await sut.GetPublishedFileDetailsAsync(123);
 
@@ -123,7 +124,7 @@ public class SteamWebApiClientTests
         var handler = new RecordingHandler((_, _) =>
             Task.FromResult(new HttpResponseMessage(HttpStatusCode.BadGateway)));
         var client = new HttpClient(handler);
-        var sut = new SteamWebApiClient(client, Substitute.For<ILogger<SteamWebApiClient>>());
+        var sut = new SteamWebApiClient(client, Substitute.For<ILogger<SteamWebApiClient>>(), new OutputSanitizer());
 
         await Assert.ThrowsAsync<HttpRequestException>(() =>
             sut.GetPublishedFileDetailsBatchAsync([333310405]));
@@ -154,7 +155,7 @@ public class SteamWebApiClientTests
         });
 
         var client = new HttpClient(handler);
-        var sut = new SteamWebApiClient(client, Substitute.For<ILogger<SteamWebApiClient>>());
+        var sut = new SteamWebApiClient(client, Substitute.For<ILogger<SteamWebApiClient>>(), new OutputSanitizer());
 
         var host = await sut.DiscoverCdnServerAsync();
 
@@ -166,7 +167,7 @@ public class SteamWebApiClientTests
     {
         var handler = new RecordingHandler((_, _) => throw new HttpRequestException("boom"));
         var client = new HttpClient(handler);
-        var sut = new SteamWebApiClient(client, Substitute.For<ILogger<SteamWebApiClient>>());
+        var sut = new SteamWebApiClient(client, Substitute.For<ILogger<SteamWebApiClient>>(), new OutputSanitizer());
 
         var host = await sut.DiscoverCdnServerAsync();
 

--- a/tests/KAST.Tests/UiPathSanitizationGuardTests.cs
+++ b/tests/KAST.Tests/UiPathSanitizationGuardTests.cs
@@ -1,0 +1,68 @@
+using System.Text.RegularExpressions;
+
+namespace KAST.Tests;
+
+public class UiPathSanitizationGuardTests
+{
+    private static readonly Regex PathFieldReferenceRegex = new(
+    @"@[^\r\n]*(\.InstallPath|\.LocalPath|\.ModsDirectory|\.ServersDirectory)\b",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    [Fact]
+    public void RazorMarkup_PathFieldsMustUseOutputSanitizer()
+    {
+        var repoRoot = FindRepoRoot();
+        var componentsRoot = Path.Combine(repoRoot, "src", "KAST.UI", "Components");
+
+        Assert.True(Directory.Exists(componentsRoot), $"Components folder not found: {componentsRoot}");
+
+        var violations = new List<string>();
+
+        foreach (var filePath in Directory.EnumerateFiles(componentsRoot, "*.razor", SearchOption.AllDirectories))
+        {
+            var fileText = File.ReadAllText(filePath);
+            var markupOnly = GetMarkupSection(fileText);
+            var lines = markupOnly.Split('\n');
+
+            for (var i = 0; i < lines.Length; i++)
+            {
+                var line = lines[i];
+                if (!PathFieldReferenceRegex.IsMatch(line))
+                    continue;
+
+                if (line.Contains("IsNullOrWhiteSpace(", StringComparison.Ordinal))
+                    continue;
+
+                if (line.Contains("OutputSanitizer.", StringComparison.Ordinal))
+                    continue;
+
+                var relativePath = Path.GetRelativePath(repoRoot, filePath).Replace('\\', '/');
+                violations.Add($"{relativePath}:{i + 1}: {line.Trim()}");
+            }
+        }
+
+        Assert.True(violations.Count == 0,
+            "Unsanitized path field usage detected in Razor markup. Wrap path display in OutputSanitizer.\n"
+            + string.Join("\n", violations));
+    }
+
+    private static string GetMarkupSection(string razorFileContent)
+    {
+        var codeBlockIndex = razorFileContent.IndexOf("@code", StringComparison.Ordinal);
+        return codeBlockIndex >= 0 ? razorFileContent[..codeBlockIndex] : razorFileContent;
+    }
+
+    private static string FindRepoRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "KAST.slnx")))
+                return current.FullName;
+
+            current = current.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate repository root containing KAST.slnx");
+    }
+}


### PR DESCRIPTION
## Summary

This PR introduces a centralized output/path sanitization layer to prevent absolute filesystem paths and sensitive host details from leaking into UI messages, API responses, install/mod logs, telemetry, and runtime exceptions. It applies the sanitizer consistently across core infrastructure and Razor pages, adds guardrail tests for markup usage, and updates nightly release publishing so repeated develop pushes no longer fail when the nightly tag/release already exists.

---

## Type of Change

- [x] feat — new feature
- [ ] fix — bug fix
- [ ] perf — performance improvement
- [x] refactor — code restructure, no behaviour change
- [ ] docs — documentation only
- [x] chore / ci — build, tooling, dependencies
- [ ] Breaking change — existing behaviour changes (add ! to the PR title type)

---

## What Changed

- Added IOutputSanitizer contract and OutputSanitizer implementation with support for:
  - absolute path scrubbing (Windows, Unix, UNC, file URI)
  - virtual root mapping (for safe user-facing display paths)
  - traversal normalization and fallback-to-filename behavior
  - sanitized exception formatting
- Wired sanitizer through dependency injection and integrated it into:
  - content orchestration/install flows
  - server instance/process/mod services
  - Steam-related services and endpoint handling
  - UI notifications, step details, install logs, and error display paths
- Updated Razor components to use sanitized output rather than raw path-containing messages.
- Added workflow hardening for nightly release publishing:
  - move nightly tag to current commit safely
  - create or update nightly prerelease idempotently
  - upload nightly artifacts with clobber behavior to avoid duplicate asset failures
- Minor UI behavior improvements included in this branch:
  - mods tab bulk actions (load all / unload all)
  - preset import behavior refined for client-side replacement flow

---

## Testing

- [ ] Existing tests pass (dotnet test)
- [x] New tests added for the changed behaviour
- [ ] Manually tested — describe below if relevant

New/expanded test coverage includes:
- OutputSanitizer unit tests for path root stripping, traversal handling, virtual root mapping, symlink-related cases, and exception/message sanitization.
- UI path sanitization guard tests that scan Razor markup and fail if sensitive path fields are rendered without sanitizer usage.
- Updates to related installer/service/API tests to align with sanitized outputs.

---

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Targets the correct branch (develop for features, main for hotfixes)
- [x] No unrelated changes mixed in (whitespace, refactors, unrelated fixes)
- [ ] EF Core migration included if any entity model changed
- [x] I have read CONTRIBUTING.md

If you want, I can also provide a shorter version optimized for reviewer scanning (1-paragraph summary + 6 bullets max).